### PR TITLE
add reward referral route for existing transactions

### DIFF
--- a/src/routes/bot_data.js
+++ b/src/routes/bot_data.js
@@ -8,7 +8,6 @@ import axios from "axios";
 import { authenticateApiKey } from "../utils/auth.js";
 
 const router = express.Router();
-const g1PolygonAddress = "0xe36BD65609c08Cd17b53520293523CF4560533d0";
 
 /**
  * POST /v1/data/
@@ -146,7 +145,10 @@ router.post("/sendTokens", authenticateApiKey, async (req, res) => {
     ).data.access_token;
 
     const web3 = new Web3();
-    const contract = new web3.eth.Contract(ERC20, g1PolygonAddress);
+    const contract = new web3.eth.Contract(
+      ERC20,
+      process.env.G1_POLYGON_ADDRESS
+    );
 
     const to = (
       await axios.post(
@@ -165,7 +167,7 @@ router.post("/sendTokens", authenticateApiKey, async (req, res) => {
       {
         userId: `grindery:${req.body.tgId}`,
         chain: "matic",
-        to: [g1PolygonAddress],
+        to: [process.env.G1_POLYGON_ADDRESS],
         value: ["0x00"],
         data: [
           contract.methods["transfer"](

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -152,10 +152,10 @@ router.get(
             userTelegramID: transaction.senderTgId,
           });
 
-          // Get the recipient's wallet address based on their Telegram ID
-          const recipientWallet = await getPatchWalletAddressFromTgId(
-            transaction.senderTgId
-          );
+          // Get the recipient's wallet address based on their Telegram ID if not already existing
+          const recipientWallet =
+            transaction.recipientWallet ??
+            (await getPatchWalletAddressFromTgId(transaction.senderTgId));
 
           // Send a reward of 50 tokens using the Patch Wallet API
           const txReward = await sendTokens(

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -145,7 +145,7 @@ router.get(
           !(await rewardCollection.findOne({
             parentTransactionHash: transaction.transactionHash.substring(1, 8),
           })) &&
-          transaction.senderWalletAddress != process.env.SOURCE_WALLET_ADDRESS
+          transaction.senderWallet != process.env.SOURCE_WALLET_ADDRESS
         ) {
           // Find information about the sender of the transaction
           const sender = await usersCollection.findOne({

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -155,7 +155,7 @@ router.get(
           // Get the recipient's wallet address based on their Telegram ID if not already existing
           const recipientWallet =
             transaction.recipientWallet ??
-            (await getPatchWalletAddressFromTgId(transaction.senderTgId));
+            (await getPatchWalletAddressFromTgId(transaction.recipientTgId));
 
           // Send a reward of 50 tokens using the Patch Wallet API
           const txReward = await sendTokens(

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -166,7 +166,7 @@ router.get(
           );
 
           // Log the issuance of the reward and insert the record into the collection
-          await collection.insertOne({
+          await rewardCollection.insertOne({
             userTelegramID: transaction.senderTgId,
             responsePath: sender.responsePath,
             walletAddress: recipientWallet,

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -144,7 +144,8 @@ router.get(
           new Date(user.dateAdded) > new Date(transaction.dateAdded) &&
           !(await rewardCollection.findOne({
             parentTransactionHash: transaction.transactionHash.substring(1, 8),
-          }))
+          })) &&
+          transaction.senderWalletAddress != process.env.SOURCE_WALLET_ADDRESS
         ) {
           // Find information about the sender of the transaction
           const sender = await usersCollection.findOne({

--- a/src/utils/patchwallet.js
+++ b/src/utils/patchwallet.js
@@ -34,7 +34,7 @@ export async function getPatchWalletAddressFromTgId(tgId) {
 
 export async function sendTokens(
   senderTgId,
-  recipientTgId,
+  recipientwallet,
   amountEther,
   patchWalletAccessToken
 ) {
@@ -51,7 +51,7 @@ export async function sendTokens(
       value: ["0x00"],
       data: [
         g1Contract.methods["transfer"](
-          await getPatchWalletAddressFromTgId(recipientTgId),
+          recipientwallet,
           Web3.utils.toWei(amountEther)
         ).encodeABI(),
       ],

--- a/src/utils/patchwallet.js
+++ b/src/utils/patchwallet.js
@@ -1,0 +1,68 @@
+import "dotenv/config";
+import axios from "axios";
+import Web3 from "web3";
+import ERC20 from "../routes/abi/ERC20.json" assert { type: "json" };
+
+export async function getPatchWalletAccessToken() {
+  return (
+    await axios.post(
+      "https://paymagicapi.com/v1/auth",
+      {
+        client_id: process.env.CLIENT_ID,
+        client_secret: process.env.CLIENT_SECRET,
+      },
+      {
+        timeout: 100000,
+      }
+    )
+  ).data.access_token;
+}
+
+export async function getPatchWalletAddressFromTgId(tgId) {
+  return (
+    await axios.post(
+      "https://paymagicapi.com/v1/resolver",
+      {
+        userIds: `grindery:${tgId}`,
+      },
+      {
+        timeout: 100000,
+      }
+    )
+  ).data.users[0].accountAddress;
+}
+
+export async function sendTokens(
+  senderTgId,
+  recipientTgId,
+  amountEther,
+  patchWalletAccessToken
+) {
+  const g1Contract = new new Web3().eth.Contract(
+    ERC20,
+    process.env.G1_POLYGON_ADDRESS
+  );
+  await axios.post(
+    "https://paymagicapi.com/v1/kernel/tx",
+    {
+      userId: `grindery:${senderTgId}`,
+      chain: "matic",
+      to: [process.env.G1_POLYGON_ADDRESS],
+      value: ["0x00"],
+      data: [
+        g1Contract.methods["transfer"](
+          await getPatchWalletAddressFromTgId(recipientTgId),
+          Web3.utils.toWei(amountEther)
+        ).encodeABI(),
+      ],
+      auth: "",
+    },
+    {
+      timeout: 100000,
+      headers: {
+        Authorization: `Bearer ${patchWalletAccessToken}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+}


### PR DESCRIPTION
## Summary

This pull request introduces a new route, `/reward-referral-transactions`, to analyze and reward users based on specific conditions within the MongoDB database. The route performs the following key tasks:

1. Obtains the Patch Wallet API access token and tracks the last token renewal time.
2. Iterates through transactions collection.
6. Renews the Patch Wallet access token if more than 50 minutes have passed since the last renewal.
7. Issues a reward of 50 tokens to eligible users using the Patch Wallet API (users who registered after a transaction was sent to them but now exist in our user database and if this transaction has not yet been rewarded, not being present in our rewards database + the sender of the transaction is not the master wallet)
8. Inserts reward information into the rewards collection.
9. Responds with a success message indicating the completion of the reward issuance process.

This route is designed to automate the process of rewarding users based on specific criteria.
