### PR TITLE
add patchwallet script to fill missing addresses in db

### DIFF
--- a/src/scripts/patchwallet.js
+++ b/src/scripts/patchwallet.js
@@ -1,0 +1,41 @@
+import { Database } from "../db/conn.js";
+import { getPatchWalletAddressFromTgId } from "../utils/patchwallet.js";
+
+async function updatePatchWalletAddresses() {
+  let db;
+  try {
+    db = await Database.getInstance();
+    const collectionUsers = db.collection("users");
+
+    for (const user of await collectionUsers
+      .find({ patchwallet: "" })
+      .toArray()) {
+      try {
+        await collectionUsers.updateOne(
+          { _id: user._id },
+          {
+            $set: {
+              patchwallet: await getPatchWalletAddressFromTgId(
+                user.userTelegramID
+              ),
+            },
+          }
+        );
+
+        console.log(
+          `Updated PatchWallet address for user ${user.userTelegramID}`
+        );
+      } catch (error) {
+        console.error(
+          `Error updating PatchWallet address for user ${user.userTelegramID}: ${error.message}`
+        );
+      }
+    }
+
+    console.log("Update completed.");
+  } catch (error) {
+    console.error(`An error occurred: ${error.message}`);
+  } finally {
+    process.exit(0);
+  }
+}


### PR DESCRIPTION
# Update PatchWallet Addresses

## Description
This pull request adds the script responsible for populating the `patchwallet` field in the MongoDB database for specific users. The script uses the `getPatchWalletAddressFromTgId` function to fetch and update the PatchWallet addresses.

## Update PatchWallet Addresses Function

The `updatePatchWalletAddresses` function performs the following tasks:

- Establishes a connection to a MongoDB database.
- Retrieves "users" collection from the database.
- Iterates through users with empty "patchwallet" fields.
- Calls the `getPatchWalletAddressFromTgId` function to fetch PatchWallet addresses based on Telegram IDs.
- Updates user documents with the obtained PatchWallet addresses.
- Logs updates and errors.
- Exits the script upon completion.


