### PR TITLE
add script for missing rewards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bignumber.js": "^9.1.1",
         "body-parser": "^1.20.2",
         "csv-parser": "^3.0.0",
+        "csv-writer": "^1.6.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-jsdoc-swagger": "^1.8.0",
@@ -1317,6 +1318,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -5629,6 +5635,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
     },
     "d": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bignumber.js": "^9.1.1",
     "body-parser": "^1.20.2",
     "csv-parser": "^3.0.0",
+    "csv-writer": "^1.6.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-jsdoc-swagger": "^1.8.0",

--- a/src/routes/db.js
+++ b/src/routes/db.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { Database } from "../db/conn.js";
 import { authenticateApiKey } from "../utils/auth.js";
+import { distributeReferralRewards } from "../scripts/rewards.js";
 
 const router = express.Router();
 
@@ -33,5 +34,21 @@ router.get("/:collectionName", authenticateApiKey, async (req, res) => {
     return res.status(500).send({ msg: "An error occurred", error });
   }
 });
+
+router.post(
+  "/distributeReferralRewards",
+  authenticateApiKey,
+  async (req, res) => {
+    try {
+      await distributeReferralRewards();
+
+      res
+        .status(200)
+        .send({ message: "Referral rewards distributed successfully." });
+    } catch (error) {
+      res.status(500).send({ message: "An error occurred", error });
+    }
+  }
+);
 
 export default router;

--- a/src/routes/db.js
+++ b/src/routes/db.js
@@ -5,6 +5,22 @@ import { distributeReferralRewards } from "../scripts/rewards.js";
 
 const router = express.Router();
 
+router.post(
+  "/distributeReferralRewards",
+  authenticateApiKey,
+  async (req, res) => {
+    try {
+      await distributeReferralRewards();
+
+      res
+        .status(200)
+        .send({ message: "Referral rewards distributed successfully." });
+    } catch (error) {
+      res.status(500).send({ message: "An error occurred", error });
+    }
+  }
+);
+
 router.post("/:collectionName", authenticateApiKey, async (req, res) => {
   const collectionName = req.params.collectionName;
   const db = await Database.getInstance(req);
@@ -34,21 +50,5 @@ router.get("/:collectionName", authenticateApiKey, async (req, res) => {
     return res.status(500).send({ msg: "An error occurred", error });
   }
 });
-
-router.post(
-  "/distributeReferralRewards",
-  authenticateApiKey,
-  async (req, res) => {
-    try {
-      await distributeReferralRewards();
-
-      res
-        .status(200)
-        .send({ message: "Referral rewards distributed successfully." });
-    } catch (error) {
-      res.status(500).send({ message: "An error occurred", error });
-    }
-  }
-);
 
 export default router;

--- a/src/scripts/rewards.js
+++ b/src/scripts/rewards.js
@@ -1,0 +1,90 @@
+import { Database } from "../db/conn.js";
+import { getPatchWalletAccessToken, sendTokens } from "../utils/patchwallet.js";
+
+/**
+ * Distributes a sign-up reward of 100 Grindery One Tokens to users without previous rewards.
+ * Renewal of Patch Wallet access token is handled.
+ */
+async function distributeSignupRewards() {
+  try {
+    // Connect to the database
+    const db = await Database.getInstance();
+    const rewardsCollection = db.collection("rewards");
+
+    // Aggregate users and rewards to find users without previous rewards
+    const usersWithoutRewards = await db
+      .collection("users")
+      .aggregate([
+        {
+          $lookup: {
+            from: "rewards",
+            localField: "userTelegramID",
+            foreignField: "userTelegramID",
+            as: "rewards",
+          },
+        },
+        {
+          $match: {
+            "rewards.amount": { $ne: "100" },
+          },
+        },
+      ])
+      .toArray();
+
+    // Log users without rewards for reference
+    console.log("Users without rewards:", usersWithoutRewards);
+
+    // Obtain the initial PatchWallet access token
+    let patchWalletAccessToken = await getPatchWalletAccessToken();
+
+    // Track the time of the last token renewal
+    let lastTokenRenewalTime = Date.now();
+
+    // Iterate through users without rewards and distribute sign-up rewards
+    for (const user of usersWithoutRewards) {
+      // Check if it's time to renew the PatchWallet access token
+      if (Date.now() - lastTokenRenewalTime >= 50 * 60 * 1000) {
+        patchWalletAccessToken = await getPatchWalletAccessToken();
+        lastTokenRenewalTime = Date.now();
+      }
+
+      // Send the sign-up reward to the user's wallet
+      const txReward = await sendTokens(
+        process.env.SOURCE_TG_ID, // Sender's Telegram ID
+        user.patchwallet, // User's wallet address
+        100, // Amount of the reward
+        patchWalletAccessToken // Access token for PatchWallet API
+      );
+
+      // Log the issuance of the reward and insert the record into the rewards collection
+      await rewardsCollection.insertOne({
+        userTelegramID: user.userTelegramID,
+        responsePath: user.responsePath,
+        walletAddress: user.patchwallet,
+        reason: "user_sign_up",
+        userHandle: sender.userHandle,
+        userName: sender.userName,
+        amount: "100",
+        message:
+          "Thank you for signing up. Here are your first 100 Grindery One Tokens.",
+        transactionHash: txReward.data.txHash,
+      });
+
+      console.log(
+        `User ${user.userTelegramID} has been rewarded for signing up.`
+      );
+    }
+
+    // Log completion message
+    console.log("All sign-up rewards have been distributed.");
+  } catch (error) {
+    // Handle errors and log them
+    console.error("An error occurred:", error);
+  } finally {
+    // Exit the script
+    process.exit(0);
+  }
+}
+
+// Execute the function to distribute sign-up rewards to eligible users
+distributeSignupRewards();

--- a/src/scripts/rewards.js
+++ b/src/scripts/rewards.js
@@ -11,68 +11,75 @@ async function distributeSignupRewards() {
     const db = await Database.getInstance();
     const rewardsCollection = db.collection("rewards");
 
-    // Aggregate users and rewards to find users without previous rewards
-    const usersWithoutRewards = await db
-      .collection("users")
-      .aggregate([
-        {
-          $lookup: {
-            from: "rewards",
-            localField: "userTelegramID",
-            foreignField: "userTelegramID",
-            as: "rewards",
-          },
-        },
-        {
-          $match: {
-            "rewards.amount": { $ne: "100" },
-          },
-        },
-      ])
-      .toArray();
-
-    // Log users without rewards for reference
-    console.log("Users without rewards:", usersWithoutRewards);
-
     // Obtain the initial PatchWallet access token
     let patchWalletAccessToken = await getPatchWalletAccessToken();
 
     // Track the time of the last token renewal
     let lastTokenRenewalTime = Date.now();
 
-    // Iterate through users without rewards and distribute sign-up rewards
-    for (const user of usersWithoutRewards) {
-      // Check if it's time to renew the PatchWallet access token
-      if (Date.now() - lastTokenRenewalTime >= 50 * 60 * 1000) {
-        patchWalletAccessToken = await getPatchWalletAccessToken();
-        lastTokenRenewalTime = Date.now();
+    const allUsers = await db.collection("users").find({}).toArray();
+    let userCount = 0;
+
+    // Load all rewards into memory for filtering
+    const allRewards = await rewardsCollection
+      .find({ amount: "100" })
+      .toArray();
+
+    for (const user of allUsers) {
+      userCount++;
+
+      // Check if there are no rewards for the current user
+      if (
+        !allRewards.some(
+          (reward) => reward.userTelegramID === user.userTelegramID
+        )
+      ) {
+        console.log(
+          `[${userCount}/${allUsers.length}] User ${user.userTelegramID} has no reward with amount "100"`
+        );
+
+        // Check if it's time to renew the PatchWallet access token
+        if (Date.now() - lastTokenRenewalTime >= 50 * 60 * 1000) {
+          patchWalletAccessToken = await getPatchWalletAccessToken();
+          lastTokenRenewalTime = Date.now();
+
+          console.log("PatchWallet access token has been updated.");
+        }
+
+        try {
+          // Send the sign-up reward to the user's wallet
+          const txReward = await sendTokens(
+            process.env.SOURCE_TG_ID, // Sender's Telegram ID
+            user.patchwallet, // User's wallet address
+            "100", // Amount of the reward
+            patchWalletAccessToken // Access token for PatchWallet API
+          );
+
+          if (txReward.data.txHash) {
+            // Log the issuance of the reward and insert the record into the rewards collection
+            await rewardsCollection.insertOne({
+              userTelegramID: user.userTelegramID,
+              responsePath: user.responsePath,
+              walletAddress: user.patchwallet,
+              reason: "user_sign_up",
+              userHandle: user.userHandle,
+              userName: user.userName,
+              amount: "100",
+              message:
+                "Thank you for signing up. Here are your first 100 Grindery One Tokens.",
+              transactionHash: txReward.data.txHash,
+              dateAdded: new Date(Date.now()),
+            });
+
+            console.log(
+              `[${userCount}/${allUsers.length}] User ${user.userTelegramID} has been rewarded for signing up.`
+            );
+          }
+        } catch (error) {
+          // Handle errors and log them
+          console.error("An error occurred during reward distribution:", error);
+        }
       }
-
-      // Send the sign-up reward to the user's wallet
-      const txReward = await sendTokens(
-        process.env.SOURCE_TG_ID, // Sender's Telegram ID
-        user.patchwallet, // User's wallet address
-        100, // Amount of the reward
-        patchWalletAccessToken // Access token for PatchWallet API
-      );
-
-      // Log the issuance of the reward and insert the record into the rewards collection
-      await rewardsCollection.insertOne({
-        userTelegramID: user.userTelegramID,
-        responsePath: user.responsePath,
-        walletAddress: user.patchwallet,
-        reason: "user_sign_up",
-        userHandle: sender.userHandle,
-        userName: sender.userName,
-        amount: "100",
-        message:
-          "Thank you for signing up. Here are your first 100 Grindery One Tokens.",
-        transactionHash: txReward.data.txHash,
-      });
-
-      console.log(
-        `User ${user.userTelegramID} has been rewarded for signing up.`
-      );
     }
 
     // Log completion message

--- a/src/scripts/rewards.js
+++ b/src/scripts/rewards.js
@@ -86,5 +86,114 @@ async function distributeSignupRewards() {
   }
 }
 
-// // Execute the function to distribute sign-up rewards to eligible users
-// distributeSignupRewards();
+async function distributeReferralRewards() {
+  try {
+    // Connect to the database
+    const db = await Database.getInstance();
+    const usersCollection = db.collection("users");
+    const rewardsCollection = db.collection("rewards");
+
+    // Obtain the initial PatchWallet access token
+    let patchWalletAccessToken = await getPatchWalletAccessToken();
+
+    // Track the time of the last token renewal
+    let lastTokenRenewalTime = Date.now();
+
+    // Create an array to store rewarded users
+    const rewardedUsers = [];
+
+    // Iterate through transfers
+    for (const transfer of await db
+      .collection("transfers")
+      .find({})
+      .toArray()) {
+      // Find the recipient user based on their Telegram ID
+      const recipientUser = await usersCollection.findOne({
+        userTelegramID: transfer.recipientTgId,
+      });
+
+      // Check if the recipient user became a user before or after the transfer
+      if (
+        !recipientUser ||
+        (recipientUser &&
+          new Date(recipientUser.dateAdded) < new Date(transfer.dateAdded))
+      ) {
+        // The user was already a user before the transfer, so no action needed
+        continue;
+      }
+
+      // Check if a reward for this transfer has already been issued
+      if (
+        await rewardsCollection.findOne({
+          parentTransactionHash: transfer.TxId,
+        })
+      ) {
+        // A reward has already been issued for this transfer, so skip to the next one
+        continue;
+      }
+
+      // Check if it's time to renew the PatchWallet access token
+      if (Date.now() - lastTokenRenewalTime >= 50 * 60 * 1000) {
+        patchWalletAccessToken = await getPatchWalletAccessToken();
+        lastTokenRenewalTime = Date.now();
+      }
+
+      // Find information about the sender of the transaction
+      const senderUser = await usersCollection.findOne({
+        userTelegramID: transfer.senderTgId,
+      });
+
+      if (senderUser) {
+        // Get the sender's wallet address based on their Telegram ID if not already existing
+        const rewardWallet =
+          senderUser.patchwallet ??
+          (await getPatchWalletAddressFromTgId(transfer.senderTgId));
+
+        // Send a reward of 50 tokens using the Patch Wallet API
+        const txReward = await sendTokens(
+          process.env.SOURCE_TG_ID,
+          rewardWallet,
+          50, // Amount of the reward
+          patchWalletAccessToken
+        );
+
+        // Log the issuance of the reward and insert the record into the rewards collection
+        await rewardsCollection.insertOne({
+          userTelegramID: senderUser.userTelegramID,
+          responsePath: senderUser.responsePath,
+          walletAddress: rewardWallet,
+          reason: "2x_reward",
+          userHandle: senderUser.userHandle,
+          userName: senderUser.userName,
+          amount: "50",
+          message:
+            "Thank you for sending tokens. Here is your 50 token reward in Grindery One Tokens.",
+          transactionHash: txReward.data.txHash,
+        });
+
+        // Add the rewarded user to the array
+        rewardedUsers.push(senderUser.userTelegramID);
+
+        console.log(
+          `User ${senderUser.userTelegramID} has been rewarded for sending tokens.`
+        );
+      }
+    }
+
+    // Log completion message
+    console.log("All transfer rewards have been issued.");
+
+    // Return the array of rewarded users for further verification
+    return rewardedUsers;
+  } catch (error) {
+    // Handle errors and log them
+    console.error("An error occurred:", error);
+    return []; // Return an empty array in case of an error
+  } finally {
+    // Exit the script
+    process.exit(0);
+  }
+}
+
+// // Execute the function to distribute rewards to eligible users and get the rewarded users
+// const rewardedUsers = distributeReferralRewards();

--- a/src/scripts/rewards.js
+++ b/src/scripts/rewards.js
@@ -86,5 +86,5 @@ async function distributeSignupRewards() {
   }
 }
 
-// Execute the function to distribute sign-up rewards to eligible users
-distributeSignupRewards();
+// // Execute the function to distribute sign-up rewards to eligible users
+// distributeSignupRewards();

--- a/src/scripts/transfers.js
+++ b/src/scripts/transfers.js
@@ -1,0 +1,39 @@
+import { Database } from "../db/conn.js";
+
+// Example usage of the functions:
+// removeDuplicateTransfers();
+async function removeDuplicateTransfers() {
+  try {
+    const db = await Database.getInstance();
+    const collectionTransfers = db.collection("transfers");
+
+    // Aggregation pipeline to identify duplicates and keep the first instance
+    const aggregationPipeline = [
+      {
+        $group: {
+          _id: "$transactionHash",
+          firstInstance: { $first: "$_id" },
+        },
+      },
+    ];
+
+    // Find the first instance of each duplicate transactionHash
+    const firstInstances = await collectionTransfers
+      .aggregate(aggregationPipeline)
+      .toArray();
+
+    // Create an array of _id values to keep (first instances)
+    const idsToKeep = firstInstances.map((instance) => instance.firstInstance);
+
+    // Delete all documents that are not in the idsToKeep array
+    const deleteResult = await collectionTransfers.deleteMany({
+      _id: { $nin: idsToKeep },
+    });
+
+    console.log(`Deleted ${deleteResult.deletedCount} duplicate transfers.`);
+  } catch (error) {
+    console.error(`An error occurred: ${error.message}`);
+  } finally {
+    process.exit(0);
+  }
+}

--- a/src/utils/patchwallet.js
+++ b/src/utils/patchwallet.js
@@ -42,7 +42,7 @@ export async function sendTokens(
     ERC20,
     process.env.G1_POLYGON_ADDRESS
   );
-  await axios.post(
+  return await axios.post(
     "https://paymagicapi.com/v1/kernel/tx",
     {
       userId: `grindery:${senderTgId}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,11 @@ csv-parser@^3.0.0:
   dependencies:
     minimist "^1.2.0"
 
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
+
 d@^1.0.1, d@1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz"


### PR DESCRIPTION
## Description:

This PR introduces two scripts for user reward distribution.

### 1. Script: `distributeSignupRewards`
- Distributes a sign-up reward of 100 Grindery One Tokens to users without previous rewards.
- Identifies eligible users based on their reward history.

### 2. Script: `distributeReferralRewards`
- Distributes referral rewards of 50 Grindery One Tokens to senders of eligible transactions.
- Ensures that rewards are not duplicated for the same transaction.

