### PR TITLE
Leaderboard Endpoint

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import data from "./routes/bot_data.js";
 import telegram from "./routes/telegram.js";
 import db from "./routes/db.js";
 import support from "./routes/support.js";
+import leaderboard from "./routes/leaderboard.js";
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use("/data", data);
 router.use("/telegram", telegram);
 router.use("/db", db);
 router.use("/support", support);
+router.use("/leaderboard", leaderboard);
 
 export default router;

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -5,7 +5,7 @@ import {authenticateApiKey} from "../utils/auth.js";
 const router = express.Router();
 
 /**
- * GET /v1/txSent
+ * GET /v1/tx-sent
  *
  * @summary Get leaderboard for transactions sent
  * @description Retrieves a leaderboard showing users who have sent the most transactions.
@@ -30,13 +30,17 @@ const router = express.Router();
  *   "error": "Server error description"
  * }
  */
-router.get("/txSent", authenticateApiKey, async (req, res) => {
+router.get("/tx-sent", async (req, res) => {
   const {days, topX, limit = 10, skip = 0} = req.query;
 
   try {
     const db = await Database.getInstance(req);
 
     let dateFilter = {};
+
+    if (topX && isNaN(parseInt(topX))) {
+      return res.status(400).send({msg: "Invalid value for topX."});
+    }
 
     if (days && !isNaN(days)) {
       dateFilter = {
@@ -51,7 +55,7 @@ router.get("/txSent", authenticateApiKey, async (req, res) => {
       {$group: {_id: "$senderTgId", count: {$sum: 1}}},
       {$sort: {count: -1}},
       {$skip: parseInt(skip)},
-      {$limit: parseInt(limit)},
+      {$limit: topX ? parseInt(topX) : parseInt(limit)},
     ];
 
     if (topX && !isNaN(topX)) {
@@ -70,24 +74,22 @@ router.get("/txSent", authenticateApiKey, async (req, res) => {
 });
 
 /**
- * GET /v1/txSent
+ * GET /v1/tokens-sent
  *
- * @summary Get leaderboard for transactions sent
- * @description Retrieves a leaderboard showing users who have sent the most transactions.
+ * @summary Get leaderboard for tokens sent
+ * @description Retrieves a leaderboard showing users who have sent the most tokens in a given period.
  * @tags Leaderboard
  * @param {string} [request.query.days] - The number of past days to filter results by.
  * @param {string} [request.query.topX] - Limit results to the top X users.
  * @param {string} [request.query.limit=10] - Number of results per page.
  * @param {string} [request.query.skip=0] - Number of results to skip for pagination.
- * @return {object} 200 - Array of users and their transaction counts.
+ * @return {object} 200 - Array of users and their total tokens sent.
  * @return {object} 500 - Error response.
  * @example response - 200 - Success response example
  * [
  *   {
  *     "_id": "1899307514",
- *       "totalTokens": {
- *       "$numberDecimal": "83580"
- *     }
+ *     "totalTokens": "100"
  *   },
  *   ...
  * ]
@@ -97,13 +99,17 @@ router.get("/txSent", authenticateApiKey, async (req, res) => {
  *   "error": "Server error description"
  * }
  */
-router.get("/tokensSent", authenticateApiKey, async (req, res) => {
+router.get("/tokensent", authenticateApiKey, async (req, res) => {
   const {days, limit = 10, skip = 0, topX} = req.query;
 
   try {
     const db = await Database.getInstance(req);
 
     let dateFilter = {};
+
+    if (topX && isNaN(parseInt(topX))) {
+      return res.status(400).send({msg: "Invalid value for topX."});
+    }
 
     if (days && !isNaN(days)) {
       dateFilter = {
@@ -170,6 +176,10 @@ router.get("/rewards", authenticateApiKey, async (req, res) => {
   const {days, skip = 0, limit = 10, topX} = req.query;
 
   let dateFilter = {};
+
+  if (topX && isNaN(parseInt(topX))) {
+    return res.status(400).send({msg: "Invalid value for topX."});
+  }
 
   if (days && !isNaN(days)) {
     dateFilter = {

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -1,0 +1,125 @@
+import express from "express";
+import {Database} from "../db/conn.js";
+import {authenticateApiKey} from "../utils/auth.js";
+
+const router = express.Router();
+
+router.get("/txSent", authenticateApiKey, async (req, res) => {
+  const {days, topX, limit = 10, skip = 0} = req.query;
+
+  try {
+    const db = await Database.getInstance(req);
+
+    let dateFilter = {};
+
+    if (days && !isNaN(days)) {
+      dateFilter = {
+        dateAdded: {
+          $gte: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+        },
+      };
+    }
+
+    const pipeline = [
+      {$match: dateFilter},
+      {$group: {_id: "$senderTgId", count: {$sum: 1}}},
+      {$sort: {count: -1}},
+      {$skip: parseInt(skip)},
+      {$limit: parseInt(limit)},
+    ];
+
+    if (topX && !isNaN(topX)) {
+      pipeline.push({$limit: parseInt(topX)});
+    }
+
+    const results = await db
+      .collection("transfers")
+      .aggregate(pipeline)
+      .toArray();
+
+    return res.status(200).send(results);
+  } catch (error) {
+    return res.status(500).send({msg: "An error occurred", error});
+  }
+});
+
+router.get("/tokensSent", authenticateApiKey, async (req, res) => {
+  const {days, limit = 10, skip = 0, topX} = req.query;
+
+  try {
+    const db = await Database.getInstance(req);
+
+    let dateFilter = {};
+
+    if (days && !isNaN(days)) {
+      dateFilter = {
+        dateAdded: {
+          $gte: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+        },
+      };
+    }
+
+    const pipeline = [
+      {$match: dateFilter},
+      {
+        $group: {
+          _id: "$senderTgId",
+          totalTokens: {$sum: {$toDecimal: "$tokenAmount"}},
+        },
+      },
+      {$sort: {totalTokens: -1}},
+      {$skip: parseInt(skip)},
+      {$limit: topX ? parseInt(topX) : parseInt(limit)},
+    ];
+
+    const results = await db
+      .collection("transfers")
+      .aggregate(pipeline)
+      .toArray();
+
+    return res.status(200).send(results);
+  } catch (error) {
+    console.log(error);
+    return res.status(500).send({msg: "An error occurred", error});
+  }
+});
+
+router.get("/rewards", authenticateApiKey, async (req, res) => {
+  const {days, skip = 0, limit = 10, topX} = req.query;
+
+  let dateFilter = {};
+
+  if (days && !isNaN(days)) {
+    dateFilter = {
+      dateAdded: {
+        $gte: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      },
+    };
+  }
+
+  try {
+    const db = await Database.getInstance(req);
+    const pipeline = [
+      {$match: dateFilter},
+      {
+        $group: {
+          _id: "$userTelegramID",
+          totalRewards: {$sum: {$toDecimal: "$amount"}},
+        },
+      },
+      {$sort: {totalRewards: -1}},
+      {$skip: parseInt(skip)},
+      {$limit: topX ? parseInt(topX) : parseInt(limit)},
+    ];
+
+    const leaderboard = await db
+      .collection("rewards")
+      .aggregate(pipeline)
+      .toArray();
+    return res.status(200).send(leaderboard);
+  } catch (error) {
+    return res.status(500).send({msg: "An error occurred", error});
+  }
+});
+
+export default router;

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -4,6 +4,32 @@ import {authenticateApiKey} from "../utils/auth.js";
 
 const router = express.Router();
 
+/**
+ * GET /v1/txSent
+ *
+ * @summary Get leaderboard for transactions sent
+ * @description Retrieves a leaderboard showing users who have sent the most transactions.
+ * @tags Leaderboard
+ * @param {string} [request.query.days] - The number of past days to filter results by.
+ * @param {string} [request.query.topX] - Limit results to the top X users.
+ * @param {string} [request.query.limit=10] - Number of results per page.
+ * @param {string} [request.query.skip=0] - Number of results to skip for pagination.
+ * @return {object} 200 - Array of users and their transaction counts.
+ * @return {object} 500 - Error response.
+ * @example response - 200 - Success response example
+ * [
+ *   {
+ *     "_id": "1899307514",
+ *     "count": 15
+ *   },
+ *   ...
+ * ]
+ * @example response - 500 - Error response example
+ * {
+ *   "msg": "An error occurred",
+ *   "error": "Server error description"
+ * }
+ */
 router.get("/txSent", authenticateApiKey, async (req, res) => {
   const {days, topX, limit = 10, skip = 0} = req.query;
 
@@ -43,6 +69,34 @@ router.get("/txSent", authenticateApiKey, async (req, res) => {
   }
 });
 
+/**
+ * GET /v1/txSent
+ *
+ * @summary Get leaderboard for transactions sent
+ * @description Retrieves a leaderboard showing users who have sent the most transactions.
+ * @tags Leaderboard
+ * @param {string} [request.query.days] - The number of past days to filter results by.
+ * @param {string} [request.query.topX] - Limit results to the top X users.
+ * @param {string} [request.query.limit=10] - Number of results per page.
+ * @param {string} [request.query.skip=0] - Number of results to skip for pagination.
+ * @return {object} 200 - Array of users and their transaction counts.
+ * @return {object} 500 - Error response.
+ * @example response - 200 - Success response example
+ * [
+ *   {
+ *     "_id": "1899307514",
+ *       "totalTokens": {
+ *       "$numberDecimal": "83580"
+ *     }
+ *   },
+ *   ...
+ * ]
+ * @example response - 500 - Error response example
+ * {
+ *   "msg": "An error occurred",
+ *   "error": "Server error description"
+ * }
+ */
 router.get("/tokensSent", authenticateApiKey, async (req, res) => {
   const {days, limit = 10, skip = 0, topX} = req.query;
 
@@ -84,6 +138,34 @@ router.get("/tokensSent", authenticateApiKey, async (req, res) => {
   }
 });
 
+/**
+ * GET /v1/rewards
+ *
+ * @summary Get leaderboard for rewards accumulated
+ * @description Retrieves a leaderboard showing users with the most accumulated rewards.
+ * @tags Leaderboard
+ * @param {string} [request.query.days] - The number of past days to filter results by.
+ * @param {string} [request.query.topX] - Limit results to the top X users.
+ * @param {string} [request.query.limit=10] - Number of results per page.
+ * @param {string} [request.query.skip=0] - Number of results to skip for pagination.
+ * @return {object} 200 - Array of users and their total rewards accumulated.
+ * @return {object} 500 - Error response.
+ * @example response - 200 - Success response example
+ * [
+ *   {
+ *     "_id": "66670057",
+ *       "totalRewards": {
+ *       "$numberDecimal": "2800"
+ *     }
+ *   },
+ *   ...
+ * ]
+ * @example response - 500 - Error response example
+ * {
+ *   "msg": "An error occurred",
+ *   "error": "Server error description"
+ * }
+ */
 router.get("/rewards", authenticateApiKey, async (req, res) => {
   const {days, skip = 0, limit = 10, topX} = req.query;
 


### PR DESCRIPTION
### /tx-sent:
Fetch the top 5 users who sent the most transactions over the last 7 days, second page (assuming a limit of 10 per page):
`v1/tx-sent?days=7&topX=5&limit=10&skip=10`

### /tokens-sent:
Fetch the top 6 users who sent the most tokens over the last 15 days, third page (assuming a limit of 10 per page):

`v1/tokens-sent?days=15&topX=6&limit=10&skip=20`

### /rewards:
Fetch the top 7 users with the highest reward accumulation over the last 30 days, fourth page (assuming a limit of 10 per page):

`v1/rewards?days=30&topX=7&limit=10&skip=30`