### PR TITLE
send transfers in batch

### DIFF
--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -1,6 +1,6 @@
 import express from "express";
-import { PubSub } from "@google-cloud/pubsub";
-import { authenticateApiKey } from "../utils/auth.js";
+import {PubSub} from "@google-cloud/pubsub";
+import {authenticateApiKey} from "../utils/auth.js";
 import {
   handleNewReward,
   handleNewTransaction,
@@ -57,15 +57,15 @@ router.post("/", authenticateApiKey, async (req, res) => {
     const dataBuffer = Buffer.from(data);
     const messageId = await pubSubClient
       .topic(topicName)
-      .publishMessage({ data: dataBuffer });
+      .publishMessage({data: dataBuffer});
     if (messageId) {
-      res.json({ success: true, messageId });
+      res.json({success: true, messageId});
     } else {
-      res.status(500).json({ success: false, error: "Event wasn't saved" });
+      res.status(500).json({success: false, error: "Event wasn't saved"});
     }
   } catch (error) {
     console.error(`Received error while publishing: ${error.message}`);
-    res.status(500).json({ success: false, error: error.message });
+    res.status(500).json({success: false, error: error.message});
   }
 });
 
@@ -90,6 +90,10 @@ const listenForMessages = () => {
         // User initiated new transaction
         case "new_transaction":
           processed = await handleNewTransaction(messageData.params);
+          break;
+        case "new_transaction_batch":
+          for (let params of messageData.params)
+            await handleNewTransaction(params);
           break;
         // New user started the bot
         case "new_user":

--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -50,7 +50,7 @@ const router = express.Router();
  *   "error": "error message"
  * }
  */
-router.post("/", async (req, res) => {
+router.post("/", authenticateApiKey, async (req, res) => {
   if (Array.isArray(req.body)) {
     let isEventProcessed = [];
 


### PR DESCRIPTION
## About

New event to send multiple events.

## Description Request

- Make it easier for the user to send 1 G1 (or another amount) in a single click to their contacts who are not yet Grindery users only (filter).
- Once these tokens are sent, have access to all users who are not yet users despite sending them to notify them of reminders.

## Request and Response Body

[POST] `/v1/webhook`

Multiple events request:

```
[
    {
        "event": "event_name1",
        "params": { "param1": "value1" }
    },
    {
        "event": "event_name2",
        "params": { "param1": "value2" }
    },
    {
        "event": "event_name3",
        "params": { "param1": "value3" }
    },
    {
        "event": "event_name4",
        "params": { "param1": "value4" }
    },
    {
        "event": "event_name5",
        "params": { "param1": "value5" }
    }
]
```

Multiple events response:

```
[
    {
        "success": true,
        "messageId": "8852700785693732"
    },
    {
        "success": true,
        "messageId": "8575934810102760"
    },
    {
        "success": true,
        "messageId": "8852689550819187"
    },
    {
        "success": true,
        "messageId": "8852634071806679"
    },
    {
        "success": true,
        "messageId": "8852656274208821"
    }
]
```

Single event request:

```
{
        "event": "event_name1",
        "params": { "param1": "value1" }
}
```

Single event response:

```
{
    "success": true,
    "messageId": "8575856342014062"
}
```
