### PR TITLE
add `/unacked-messages` route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/bigquery": "^7.3.0",
+        "@google-cloud/monitoring": "^4.0.0",
         "@google-cloud/pubsub": "^4.0.5",
         "@google-cloud/storage": "^7.2.0",
         "@types/sinon": "^10.0.17",
@@ -1144,6 +1145,17 @@
         "google-auth-library": "^9.0.0",
         "retry-request": "^6.0.0",
         "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/monitoring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/monitoring/-/monitoring-4.0.0.tgz",
+      "integrity": "sha512-7HBEWbusYzcaNr6aZHqM4sUmqYS7BCh5VashxHrurXU45yTwiYgfmqhHd4P1yO5J/zpVEDXPZBI+a+8nacQoqw==",
+      "dependencies": {
+        "google-gax": "^4.0.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8910,6 +8922,14 @@
         "google-auth-library": "^9.0.0",
         "retry-request": "^6.0.0",
         "teeny-request": "^9.0.0"
+      }
+    },
+    "@google-cloud/monitoring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/monitoring/-/monitoring-4.0.0.tgz",
+      "integrity": "sha512-7HBEWbusYzcaNr6aZHqM4sUmqYS7BCh5VashxHrurXU45yTwiYgfmqhHd4P1yO5J/zpVEDXPZBI+a+8nacQoqw==",
+      "requires": {
+        "google-gax": "^4.0.3"
       }
     },
     "@google-cloud/paginator": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@google-cloud/bigquery": "^7.3.0",
+    "@google-cloud/monitoring": "^4.0.0",
     "@google-cloud/pubsub": "^4.0.5",
     "@google-cloud/storage": "^7.2.0",
     "@types/sinon": "^10.0.17",

--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -7,6 +7,7 @@ import {
   handleNewUser,
 } from '../utils/webhook.js';
 import { v4 as uuidv4 } from 'uuid';
+import { MetricServiceClient } from '@google-cloud/monitoring';
 
 /**
  * This is a generic and extendable implementation of a webhook endpoint and pub/sub messages queue.
@@ -24,6 +25,48 @@ const topicName = process.env.PUBSUB_TOPIC_NAME;
 const subscriptionName = process.env.PUBSUB_SUBSCRIPTION_NAME;
 
 const router = express.Router();
+
+router.get('/unacked-messages', async (req, res) => {
+  try {
+    const client = new MetricServiceClient();
+
+    const timeSeries = await client.listTimeSeries({
+      name: client.projectPath(process.env.PROJECT_ID),
+      filter: `metric.type="pubsub.googleapis.com/subscription/num_unacked_messages_by_region"`,
+      interval: {
+        // Limit results to the last 20 minutes
+        startTime: {
+          seconds: Date.now() / 1000 - 60 * 20,
+        },
+        endTime: {
+          seconds: Date.now() / 1000,
+        },
+      },
+    });
+
+    // Initialize the sum and count variables for calculating the average
+    let sum = 0;
+    let count = 0;
+
+    // Iterate through the timeSeries to calculate the sum
+    timeSeries?.forEach((series) => {
+      series?.forEach((serie) => {
+        serie?.points?.forEach((point) => {
+          sum += parseFloat(point.value.int64Value);
+          count++;
+        });
+      });
+    });
+
+    // Calculate the average
+    const average = count > 0 ? sum / count : 0;
+
+    // Return the result in JSON format
+    res.json({ num_unacked_messages: average });
+  } catch (error) {
+    console.error('Error querying metrics:', error);
+  }
+});
 
 /**
  * POST /v1/webhook

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,13 @@
     retry-request "^6.0.0"
     teeny-request "^9.0.0"
 
+"@google-cloud/monitoring@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@google-cloud/monitoring/-/monitoring-4.0.0.tgz"
+  integrity sha512-7HBEWbusYzcaNr6aZHqM4sUmqYS7BCh5VashxHrurXU45yTwiYgfmqhHd4P1yO5J/zpVEDXPZBI+a+8nacQoqw==
+  dependencies:
+    google-gax "^4.0.3"
+
 "@google-cloud/paginator@^5.0.0":
   version "5.0.0"
   resolved "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.0.tgz"
@@ -2862,7 +2869,7 @@ google-auth-library@^9.0.0:
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-gax@^4.0.2:
+google-gax@^4.0.2, google-gax@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/google-gax/-/google-gax-4.0.3.tgz"
   integrity sha512-gllHYRhZvpz0LcVN+xtyzBeUa/ZYiLGF4JNBECrvL/LxDkaJc09hHoQ+KzRBI2Ewqgrjj7V3QrOC2pGno5ropw==


### PR DESCRIPTION
To detect the poor health of our PubSub queue, one of the indicators is the number of non acknowledge messages. It increases drastically when failures multiply. Thus, this PR contains a new route which calculates the average of the number of non acknowledge messages over the last 20 minutes for the Pub Sub queue linked to the Telegram bot. His recurring call will alert us to potential problems.