### PR TITLE
refactor: always use constant for collection names and clean up

### DIFF
--- a/src/routes/analytics.js
+++ b/src/routes/analytics.js
@@ -1,10 +1,5 @@
-import Web3 from 'web3';
 import express from 'express';
 import 'dotenv/config';
-import ERC20 from './abi/ERC20.json' assert { type: 'json' };
-import BigNumber from 'bignumber.js';
-import { CHAIN_MAPPING } from '../utils/chains.js';
-import axios from 'axios';
 import { authenticateApiKey } from '../utils/auth.js';
 import { Database } from '../db/conn.js';
 import { TRANSFERS_COLLECTION } from '../utils/constants.js';

--- a/src/routes/bot_data.js
+++ b/src/routes/bot_data.js
@@ -4,7 +4,6 @@ import 'dotenv/config';
 import ERC20 from './abi/ERC20.json' assert { type: 'json' };
 import BigNumber from 'bignumber.js';
 import { CHAIN_MAPPING } from '../utils/chains.js';
-import axios from 'axios';
 import { authenticateApiKey } from '../utils/auth.js';
 import {
   getPatchWalletAccessToken,

--- a/src/routes/db.js
+++ b/src/routes/db.js
@@ -8,7 +8,6 @@ import {
 } from '../utils/transfers.js';
 import {
   REWARDS_COLLECTION,
-  REWARDS_TESTS_COLLECTION,
   TRANSACTION_STATUS,
   TRANSFERS_COLLECTION,
   USERS_COLLECTION,
@@ -71,12 +70,14 @@ router.get('/backlog-signup-rewards', authenticateApiKey, async (req, res) => {
 
     return res.status(200).send(
       await db
-        .collection('users')
+        .collection(USERS_COLLECTION)
         .find({
           userTelegramID: {
-            $nin: await db.collection('rewards').distinct('userTelegramID', {
-              amount: '100',
-            }),
+            $nin: await db
+              .collection(REWARDS_COLLECTION)
+              .distinct('userTelegramID', {
+                amount: '100',
+              }),
           },
         })
         .toArray()
@@ -206,7 +207,7 @@ router.get('/transactions-count', authenticateApiKey, async (req, res) => {
   try {
     const db = await Database.getInstance(req);
     const txs = await db
-      .collection('transfers')
+      .collection(TRANSFERS_COLLECTION)
       .find({ senderTgId: req.query.userId })
       .toArray();
     res
@@ -222,7 +223,7 @@ router.get('/transactions-new-users', authenticateApiKey, async (req, res) => {
     const db = await Database.getInstance(req);
 
     const txs = await db
-      .collection('transfers')
+      .collection(TRANSFERS_COLLECTION)
       .aggregate([
         {
           $match: {
@@ -266,7 +267,7 @@ router.get(
       const db = await Database.getInstance(req);
 
       const txs = await db
-        .collection('transfers')
+        .collection(TRANSFERS_COLLECTION)
         .aggregate([
           {
             $match: {
@@ -307,7 +308,7 @@ router.get('/referral-link-count', authenticateApiKey, async (req, res) => {
   try {
     const db = await Database.getInstance(req);
     const rewards = await db
-      .collection('rewards')
+      .collection(REWARDS_COLLECTION)
       .find({ userTelegramID: req.query.userId, reason: 'referral_link' })
       .toArray();
     res

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -1,6 +1,10 @@
 import express from 'express';
 import { Database } from '../db/conn.js';
 import { authenticateApiKey } from '../utils/auth.js';
+import {
+  REWARDS_COLLECTION,
+  TRANSFERS_COLLECTION,
+} from '../utils/constants.js';
 
 const router = express.Router();
 
@@ -63,7 +67,7 @@ router.get('/tx-sent', async (req, res) => {
     }
 
     const results = await db
-      .collection('transfers')
+      .collection(TRANSFERS_COLLECTION)
       .aggregate(pipeline)
       .toArray();
 
@@ -133,7 +137,7 @@ router.get('/tokensent', authenticateApiKey, async (req, res) => {
     ];
 
     const results = await db
-      .collection('transfers')
+      .collection(TRANSFERS_COLLECTION)
       .aggregate(pipeline)
       .toArray();
 
@@ -205,7 +209,7 @@ router.get('/rewards', authenticateApiKey, async (req, res) => {
     ];
 
     const leaderboard = await db
-      .collection('rewards')
+      .collection(REWARDS_COLLECTION)
       .aggregate(pipeline)
       .toArray();
     return res.status(200).send(leaderboard);

--- a/src/routes/support.js
+++ b/src/routes/support.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { Database } from '../db/conn.js';
 import { authenticateApiKey } from '../utils/auth.js';
+import { USERS_COLLECTION } from '../utils/constants.js';
 
 const router = express.Router();
 
@@ -49,7 +50,7 @@ const router = express.Router();
  */
 router.post('/import', authenticateApiKey, async (req, res) => {
   const db = await Database.getInstance(req);
-  const collection = db.collection('users');
+  const collection = db.collection(USERS_COLLECTION);
   const inputData = req.body;
   const toInsert = [];
 

--- a/src/scripts/patchwallet.js
+++ b/src/scripts/patchwallet.js
@@ -1,4 +1,5 @@
 import { Database } from '../db/conn.js';
+import { USERS_COLLECTION } from '../utils/constants.js';
 import { getPatchWalletAddressFromTgId } from '../utils/patchwallet.js';
 
 // Usage: updatePatchWalletAddresses()
@@ -9,7 +10,7 @@ async function updatePatchWalletAddresses() {
   let db;
   try {
     db = await Database.getInstance();
-    const collectionUsers = db.collection('users');
+    const collectionUsers = db.collection(USERS_COLLECTION);
 
     for (const user of await collectionUsers
       .find({

--- a/src/scripts/rewards.js
+++ b/src/scripts/rewards.js
@@ -113,7 +113,7 @@ export async function distributeReferralRewards() {
   try {
     // Connect to the database
     const db = await Database.getInstance();
-    const rewardsCollection = db.collection('rewards');
+    const rewardsCollection = db.collection(REWARDS_COLLECTION);
 
     // Obtain the initial PatchWallet access token
     let patchWalletAccessToken = await getPatchWalletAccessToken();
@@ -125,11 +125,14 @@ export async function distributeReferralRewards() {
     const rewardedUsers = [];
 
     // Export the users and rewards collections as arrays
-    const allUsers = await db.collection('users').find({}).toArray();
+    const allUsers = await db.collection(USERS_COLLECTION).find({}).toArray();
     const allRewardsReferral = await rewardsCollection
       .find({ reason: '2x_reward' })
       .toArray();
-    const allTransfers = await db.collection('transfers').find({}).toArray();
+    const allTransfers = await db
+      .collection(TRANSFERS_COLLECTION)
+      .find({})
+      .toArray();
 
     let transferCount = 0;
 
@@ -624,7 +627,7 @@ async function importMissingRewardsFromCSV(fileName) {
  */
 async function checkMissingRewards(fileName) {
   const db = await Database.getInstance();
-  const collection = db.collection('rewards');
+  const collection = db.collection(REWARDS_COLLECTION);
   const hashesInCsv = new Set();
 
   fs.createReadStream(fileName)
@@ -662,7 +665,7 @@ async function filterAndRemoveInvalidRewards() {
   try {
     // Connect to the database
     const db = await Database.getInstance();
-    const rewardsCollection = db.collection('rewards');
+    const rewardsCollection = db.collection(REWARDS_COLLECTION);
 
     // Find rewards documents where transactionHash doesn't start with "0x"
     const invalidRewards = await rewardsCollection
@@ -709,8 +712,8 @@ async function updateParentTransactionHash() {
     // Connect to the database
     const db = await Database.getInstance();
 
-    const transfersCollection = db.collection('transfers');
-    const rewardsCollection = db.collection('rewards');
+    const transfersCollection = db.collection(TRANSFERS_COLLECTION);
+    const rewardsCollection = db.collection(REWARDS_COLLECTION);
 
     // Fetch all rewards
     const allRewards = await rewardsCollection.find({}).toArray();
@@ -821,8 +824,8 @@ async function getTransactionsAndRecipientsFromId(userId) {
   try {
     // Connect to the database
     const db = await Database.getInstance();
-    const rewardsCollection = db.collection('rewards');
-    const transfersCollection = db.collection('transfers');
+    const rewardsCollection = db.collection(REWARDS_COLLECTION);
+    const transfersCollection = db.collection(TRANSFERS_COLLECTION);
 
     const rewards = await rewardsCollection
       .find({ userTelegramID: userId, reason: 'referral_link' })

--- a/src/scripts/segment.js
+++ b/src/scripts/segment.js
@@ -1,6 +1,11 @@
 import { Database } from '../db/conn.js';
 import axios from 'axios';
-import { SEGMENT_API_ENDPOINT, SEGMENT_WRITE_KEY } from '../utils/constants.js';
+import {
+  SEGMENT_API_ENDPOINT,
+  SEGMENT_WRITE_KEY,
+  TRANSFERS_COLLECTION,
+  USERS_COLLECTION,
+} from '../utils/constants.js';
 
 // Usage: sendUsersBatchRequest()
 // Description: Sends a batch request to the Segment API with user details.
@@ -10,7 +15,7 @@ import { SEGMENT_API_ENDPOINT, SEGMENT_WRITE_KEY } from '../utils/constants.js';
 // Example: sendUsersBatchRequest();
 async function sendUsersBatchRequest() {
   const db = await Database.getInstance();
-  const usersCollection = db.collection('users');
+  const usersCollection = db.collection(USERS_COLLECTION);
 
   try {
     const users = await usersCollection.find().toArray();
@@ -59,7 +64,7 @@ async function sendUsersBatchRequest() {
 // Example: sendTransfersBatchRequest();
 async function sendTransfersBatchRequest() {
   const db = await Database.getInstance();
-  const transfersCollection = db.collection('transfers');
+  const transfersCollection = db.collection(TRANSFERS_COLLECTION);
 
   try {
     const transfers = await transfersCollection.find().toArray();

--- a/src/scripts/transfers.js
+++ b/src/scripts/transfers.js
@@ -5,16 +5,16 @@ import web3 from 'web3';
 import {
   REWARDS_COLLECTION,
   TRANSFERS_COLLECTION,
+  USERS_COLLECTION,
 } from '../utils/constants.js';
 import { createObjectCsvWriter as createCsvWriter } from 'csv-writer';
-import { ObjectId } from 'mongodb';
 
 // Example usage of the functions:
 // removeDuplicateTransfers();
 async function removeDuplicateTransfers() {
   try {
     const db = await Database.getInstance();
-    const collectionTransfers = db.collection('transfers');
+    const collectionTransfers = db.collection(TRANSFERS_COLLECTION);
 
     // Aggregation pipeline to identify duplicates and keep the first instance
     const aggregationPipeline = [
@@ -53,7 +53,7 @@ async function removeDuplicateTransfers() {
 // Example: transfersCleanup("dune.csv");
 async function transfersCleanup(fileName) {
   const db = await Database.getInstance();
-  const collection = db.collection('transfers');
+  const collection = db.collection(TRANSFERS_COLLECTION);
   const hashesInCsv = [];
   let latestTimestamp = null;
 
@@ -108,10 +108,10 @@ async function updateTransfersInformations() {
     const db = await Database.getInstance();
 
     // Get the transfers collection
-    const transfersCollection = db.collection('transfers');
+    const transfersCollection = db.collection(TRANSFERS_COLLECTION);
 
     // Get the users collection
-    const usersCollection = db.collection('users');
+    const usersCollection = db.collection(USERS_COLLECTION);
 
     // Find all transfers in the collection
     const allTransfers = await transfersCollection.find({}).toArray();
@@ -234,7 +234,7 @@ async function removeRewardFromTransfers() {
  */
 async function checkMissingTransfers(fileName) {
   const db = await Database.getInstance();
-  const collection = db.collection('transfers');
+  const collection = db.collection(TRANSFERS_COLLECTION);
   const hashesInCsv = new Set();
   const excludeAddress = process.env.SOURCE_WALLET_ADDRESS;
 
@@ -274,8 +274,8 @@ async function checkMissingTransfers(fileName) {
 async function getUsersFollowUps() {
   try {
     const db = await Database.getInstance();
-    const transfersCollection = db.collection('transfers');
-    const usersCollection = db.collection('users');
+    const transfersCollection = db.collection(TRANSFERS_COLLECTION);
+    const usersCollection = db.collection(USERS_COLLECTION);
 
     const allTransfers = await transfersCollection.find({}).toArray();
     const allUsers = await usersCollection.find({}).toArray();
@@ -350,7 +350,7 @@ async function getUsersFollowUps() {
 async function getDoubleTxs() {
   try {
     const db = await Database.getInstance();
-    const collection = db.collection('transfers');
+    const collection = db.collection(TRANSFERS_COLLECTION);
 
     const csvWriter = createCsvWriter({
       path: 'matched_transactions.csv',

--- a/src/scripts/users.js
+++ b/src/scripts/users.js
@@ -2,7 +2,7 @@ import { Database } from '../db/conn.js';
 import fs from 'fs';
 import csv from 'csv-parser';
 import csvWriter from 'csv-writer';
-import { USERS_COLLECTION } from '../utils/constants.js';
+import { TRANSFERS_COLLECTION, USERS_COLLECTION } from '../utils/constants.js';
 
 // Usage: importUsersFromCSV(filePath)
 // Description: This function imports user data from a CSV file into the database.
@@ -10,7 +10,7 @@ import { USERS_COLLECTION } from '../utils/constants.js';
 // Example: importUsersFromCSV("/path/to/your/file.csv");
 async function importUsersFromCSV(filePath) {
   const db = await Database.getInstance();
-  const collection = db.collection('users');
+  const collection = db.collection(USERS_COLLECTION);
   const toInsert = [];
 
   try {
@@ -130,7 +130,7 @@ async function importUsersFromJSON(filePath) {
 async function removeUsersScientificNotationInTelegramID() {
   try {
     const db = await Database.getInstance();
-    const collectionUsers = db.collection('users');
+    const collectionUsers = db.collection(USERS_COLLECTION);
 
     // Define a filter to find users with "+" in userTelegramID
     const filter = { userTelegramID: { $regex: /\+/ } };
@@ -184,8 +184,8 @@ function logUserTelegramIDsFromArrayOfUsers(users) {
 async function getUsersWithoutOutgoingTransfersAndExportToCSV() {
   try {
     const db = await Database.getInstance();
-    const usersCollection = db.collection('users');
-    const transfersCollection = db.collection('transfers');
+    const usersCollection = db.collection(USERS_COLLECTION);
+    const transfersCollection = db.collection(TRANSFERS_COLLECTION);
 
     // Get all users
     const allUsers = await usersCollection.find({}).toArray();

--- a/src/utils/transfers.js
+++ b/src/utils/transfers.js
@@ -1,4 +1,3 @@
-import { Database } from '../db/conn.js';
 import {
   REWARDS_COLLECTION,
   TRANSFERS_COLLECTION,
@@ -55,7 +54,7 @@ export async function getOutgoingTxsToNewUsers(db, userId, start, limit) {
   return await Promise.all(
     (
       await db
-        .collection('transfers')
+        .collection(TRANSFERS_COLLECTION)
         .aggregate([
           {
             $match: {


### PR DESCRIPTION
This PR focuses on:
- Always use dedicated constants to get collection names.
- Clean up unused imports.