### PR TITLE
feat: `handleNewTransaction`should not add anything in db if sender not user

### DIFF
--- a/src/test/pubsub-new-transaction.test.js
+++ b/src/test/pubsub-new-transaction.test.js
@@ -527,7 +527,7 @@ describe('handleNewTransaction function', async function () {
       chai.expect(result).to.be.true;
     });
 
-    it('Should not modify status in database if sender is not a user', async function () {
+    it('Should not add anything in database if sender is not a user', async function () {
       const result = await handleNewTransaction({
         senderTgId: mockUserTelegramID,
         amount: '100',
@@ -535,21 +535,7 @@ describe('handleNewTransaction function', async function () {
         eventId: txId,
       });
 
-      chai
-        .expect(await collectionTransfersMock.find({}).toArray())
-        .excluding(['_id', 'dateAdded'])
-        .to.deep.equal([
-          {
-            eventId: txId,
-            chainId: 'eip155:137',
-            tokenSymbol: 'g1',
-            tokenAddress: process.env.G1_POLYGON_ADDRESS,
-            senderTgId: mockUserTelegramID,
-            recipientTgId: mockUserTelegramID1,
-            tokenAmount: '100',
-            status: TRANSACTION_STATUS.PENDING,
-          },
-        ]);
+      chai.expect(await collectionTransfersMock.find({}).toArray()).to.be.empty;
     });
 
     it('Should not send tokens if sender is not a user', async function () {

--- a/src/utils/webhooks/webhook.js
+++ b/src/utils/webhooks/webhook.js
@@ -762,6 +762,18 @@ export async function handleNewReward(params) {
 export async function handleNewTransaction(params) {
   const db = await Database.getInstance();
 
+  // Retrieve sender information from the "users" collection
+  const senderInformation = await db
+    .collection(USERS_COLLECTION)
+    .findOne({ userTelegramID: params.senderTgId });
+
+  if (!senderInformation) {
+    console.error(
+      `[${params.eventId}] Sender ${params.senderTgId} is not a user`
+    );
+    return true;
+  }
+
   const tx_db = await db
     .collection(TRANSFERS_COLLECTION)
     .findOne({ eventId: params.eventId });
@@ -795,18 +807,6 @@ export async function handleNewTransaction(params) {
   if (tx_db?.status === TRANSACTION_STATUS.FAILURE) {
     console.log(
       `[${tx_db?.transactionHash}] with event ID ${tx_db?.eventId} is already a failure.`
-    );
-    return true;
-  }
-
-  // Retrieve sender information from the "users" collection
-  const senderInformation = await db
-    .collection(USERS_COLLECTION)
-    .findOne({ userTelegramID: params.senderTgId });
-
-  if (!senderInformation) {
-    console.error(
-      `[${params.eventId}] Sender ${params.senderTgId} is not a user`
     );
     return true;
   }


### PR DESCRIPTION
This PR fix a bug in `handleNewTransaction`: the function should not add anything in database if sender is not a user.