### PR TITLE
feat: add user attributes route

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,7 @@ import db from './routes/db.js';
 import support from './routes/support.js';
 import leaderboard from './routes/leaderboard.js';
 import analytics from './routes/analytics.js';
+import users from './routes/users.js';
 
 const router = Router();
 
@@ -20,5 +21,6 @@ router.use('/db', db);
 router.use('/support', support);
 router.use('/leaderboard', leaderboard);
 router.use('/analytics', analytics);
+router.use('/users', users);
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import { Database } from '../db/conn.js';
+import { authenticateApiKey } from '../utils/auth.js';
+import { USERS_COLLECTION } from '../utils/constants.js';
+import 'dotenv/config';
+
+const router = express.Router();
+
+router.post('/attributes', authenticateApiKey, async (req, res) => {
+  try {
+    const db = await Database.getInstance();
+
+    if (!Array.isArray(req.body)) {
+      return res.status(400).send({
+        msg: 'Request body should contain an array of attribute objects.',
+      });
+    }
+
+    return res.status(200).send({
+      msg: 'Updates successful',
+      result: await db.collection(USERS_COLLECTION).bulkWrite(
+        req.body.map((update) => {
+          const { userTelegramID, attributeNames, erased_others } = update;
+
+          if (
+            !Array.isArray(attributeNames) ||
+            typeof userTelegramID !== 'string' ||
+            typeof erased_others !== 'boolean'
+          ) {
+            return res.status(400).send({
+              msg: 'Each item in the array should have "userTelegramID" as string, "attributeNames" as an array, and "erased_others" as a boolean.',
+            });
+          }
+
+          return {
+            updateOne: {
+              filter: { userTelegramID },
+              update: erased_others
+                ? { $set: { attributes: attributeNames } }
+                : {
+                    $addToSet: { attributes: { $each: attributeNames } },
+                  },
+              upsert: true,
+            },
+          };
+        })
+      ),
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(500).send({ msg: 'An error occurred', error });
+  }
+});
+
+export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -52,4 +52,29 @@ router.post('/attributes', authenticateApiKey, async (req, res) => {
   }
 });
 
+router.get('/attributes', authenticateApiKey, async (req, res) => {
+  try {
+    const { userTelegramID } = req.query;
+
+    if (!userTelegramID) {
+      return res.status(400).send({
+        msg: 'User Telegram ID is required.',
+      });
+    }
+
+    const db = await Database.getInstance();
+    const user = await db
+      .collection(USERS_COLLECTION)
+      .findOne({ userTelegramID });
+
+    return res.status(200).send({
+      userTelegramID,
+      attributes: user?.attributes,
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(500).send({ msg: 'An error occurred', error });
+  }
+});
+
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -20,26 +20,21 @@ router.post('/attributes', authenticateApiKey, async (req, res) => {
       msg: 'Updates successful',
       result: await db.collection(USERS_COLLECTION).bulkWrite(
         req.body.map((update) => {
-          const { userTelegramID, attributeNames, erased_others } = update;
+          const { userTelegramID, attributeNames } = update;
 
           if (
             !Array.isArray(attributeNames) ||
-            typeof userTelegramID !== 'string' ||
-            typeof erased_others !== 'boolean'
+            typeof userTelegramID !== 'string'
           ) {
             return res.status(400).send({
-              msg: 'Each item in the array should have "userTelegramID" as string, "attributeNames" as an array, and "erased_others" as a boolean.',
+              msg: 'Each item in the array should have "userTelegramID" as string, "attributeNames" as an array.',
             });
           }
 
           return {
             updateOne: {
               filter: { userTelegramID },
-              update: erased_others
-                ? { $set: { attributes: attributeNames } }
-                : {
-                    $addToSet: { attributes: { $each: attributeNames } },
-                  },
+              update: { $set: { attributes: attributeNames } },
               upsert: true,
             },
           };


### PR DESCRIPTION
This pull request introduces two new routes:

## POST '/attributes'

- Handles the update of user attributes based on the provided request body.
- Expects an array of attribute objects in the request body.
- Validates the structure of each object within the array (`userTelegramID`, `attributeNames`, `erased_others`).
- Updates the MongoDB collection accordingly, either overwriting existing attributes or adding new ones without duplicating based on the `erased_others` flag.


## GET '/attributes'

- Retrieves the attributes of a user based on their `userTelegramID` sent as a query parameter.
- Validates the presence of the `userTelegramID` in the query.
- Searches the MongoDB collection for the user and returns their attributes if found.