### PR TITLE
chore: add token symbol

### DIFF
--- a/src/test/pubsub-new-transaction.test.ts
+++ b/src/test/pubsub-new-transaction.test.ts
@@ -166,7 +166,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: mockChainId,
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: mockTokenAddress,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -238,6 +238,9 @@ describe('handleNewTransaction function', async function () {
         amount: '100',
         recipientTgId: mockUserTelegramID1,
         eventId: txId,
+        tokenSymbol: 'USDC',
+        tokenAddress: '0xe36BD65609c08Cd17b53520293523CF4560533d2',
+        chainId: mockChainId,
       });
 
       const segmentIdentityCall = axiosStub
@@ -251,9 +254,9 @@ describe('handleNewTransaction function', async function () {
           userId: mockUserTelegramID,
           event: 'Transfer',
           properties: {
-            chainId: 'eip155:137',
-            tokenSymbol: 'g1',
-            tokenAddress: G1_POLYGON_ADDRESS,
+            chainId: mockChainId,
+            tokenSymbol: 'USDC',
+            tokenAddress: '0xe36BD65609c08Cd17b53520293523CF4560533d2',
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
             senderName: mockUserName,
@@ -282,7 +285,7 @@ describe('handleNewTransaction function', async function () {
       chai.expect(FlowXOCallArgs).excluding(['dateAdded']).to.deep.equal({
         senderResponsePath: mockResponsePath,
         chainId: 'eip155:137',
-        tokenSymbol: 'g1',
+        tokenSymbol: 'G1',
         tokenAddress: G1_POLYGON_ADDRESS,
         senderTgId: mockUserTelegramID,
         senderWallet: mockWallet,
@@ -327,7 +330,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: mockChainId,
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: mockTokenAddress,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -614,7 +617,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: 'eip155:137',
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: G1_POLYGON_ADDRESS,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -928,7 +931,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: 'eip155:137',
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: G1_POLYGON_ADDRESS,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -1018,7 +1021,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: 'eip155:137',
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: G1_POLYGON_ADDRESS,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -1108,7 +1111,7 @@ describe('handleNewTransaction function', async function () {
           {
             eventId: txId,
             chainId: 'eip155:137',
-            tokenSymbol: 'g1',
+            tokenSymbol: 'G1',
             tokenAddress: G1_POLYGON_ADDRESS,
             senderTgId: mockUserTelegramID,
             senderWallet: mockWallet,
@@ -1200,7 +1203,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1245,7 +1248,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1298,7 +1301,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1329,7 +1332,7 @@ describe('handleNewTransaction function', async function () {
         chai.expect(FlowXOCallArgs).excluding(['dateAdded']).to.deep.equal({
           senderResponsePath: mockResponsePath,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1361,7 +1364,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1421,7 +1424,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1466,7 +1469,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1523,7 +1526,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1567,7 +1570,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1626,7 +1629,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1671,7 +1674,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1723,7 +1726,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,
@@ -1768,7 +1771,7 @@ describe('handleNewTransaction function', async function () {
         await collectionTransfersMock.insertOne({
           eventId: txId,
           chainId: 'eip155:137',
-          tokenSymbol: 'g1',
+          tokenSymbol: 'G1',
           tokenAddress: G1_POLYGON_ADDRESS,
           senderTgId: mockUserTelegramID,
           senderWallet: mockWallet,
@@ -1828,7 +1831,7 @@ describe('handleNewTransaction function', async function () {
             {
               eventId: txId,
               chainId: 'eip155:137',
-              tokenSymbol: 'g1',
+              tokenSymbol: 'G1',
               tokenAddress: G1_POLYGON_ADDRESS,
               senderTgId: mockUserTelegramID,
               senderWallet: mockWallet,

--- a/src/utils/segment.ts
+++ b/src/utils/segment.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { G1_POLYGON_ADDRESS, SEGMENT_KEY } from '../../secrets';
+import { SEGMENT_KEY } from '../../secrets';
 
 /**
  * Sends user identity information to Segment.
@@ -40,9 +40,9 @@ export async function addTrackSegment(params: any): Promise<any> {
       userId: params.userTelegramID,
       event: 'Transfer',
       properties: {
-        chainId: 'eip155:137',
-        tokenSymbol: 'g1',
-        tokenAddress: G1_POLYGON_ADDRESS,
+        chainId: params.chainId,
+        tokenSymbol: params.tokenSymbol,
+        tokenAddress: params.tokenAddress,
         senderTgId: params.senderTgId,
         senderWallet: params.senderWallet,
         senderHandle: params.senderHandle,

--- a/src/utils/transfers.ts
+++ b/src/utils/transfers.ts
@@ -201,9 +201,10 @@ export async function createTransferTelegram(
   senderInformation: object,
   recipientTgId: string,
   amount: number,
-  chainId,
-  tokenAddress,
-  chainName,
+  chainId: string,
+  tokenAddress: string,
+  chainName: string,
+  tokenSymbol: string,
 ): Promise<TransferTelegram | boolean> {
   const transfer = new TransferTelegram(
     eventId,
@@ -213,6 +214,7 @@ export async function createTransferTelegram(
     chainId,
     tokenAddress,
     chainName,
+    tokenSymbol,
   );
   return (await transfer.initializeTransferDatabase()) && transfer;
 }
@@ -235,6 +237,7 @@ export class TransferTelegram {
   chainId: string;
   tokenAddress: string;
   chainName: string;
+  tokenSymbol: string;
 
   constructor(
     eventId,
@@ -244,6 +247,7 @@ export class TransferTelegram {
     chainId,
     tokenAddress,
     chainName,
+    tokenSymbol,
   ) {
     this.eventId = eventId;
     this.senderInformation = senderInformation;
@@ -258,6 +262,7 @@ export class TransferTelegram {
     this.chainId = chainId ? chainId : 'eip155:137';
     this.tokenAddress = tokenAddress ? tokenAddress : G1_POLYGON_ADDRESS;
     this.chainName = chainName ? chainName : 'matic';
+    this.tokenSymbol = tokenSymbol ? tokenSymbol : 'G1';
   }
 
   /**
@@ -309,7 +314,7 @@ export class TransferTelegram {
         $set: {
           eventId: this.eventId,
           chainId: this.chainId,
-          tokenSymbol: 'g1',
+          tokenSymbol: this.tokenSymbol,
           tokenAddress: this.tokenAddress,
           senderTgId: this.senderInformation.userTelegramID,
           senderWallet: this.senderInformation.patchwallet,
@@ -383,6 +388,9 @@ export class TransferTelegram {
       transactionHash: this.txHash,
       dateAdded: new Date(),
       eventId: this.eventId,
+      tokenSymbol: this.tokenSymbol,
+      tokenAddress: this.tokenAddress,
+      chainId: this.chainId,
     });
   }
 
@@ -395,7 +403,7 @@ export class TransferTelegram {
     await axios.post(FLOWXO_NEW_TRANSACTION_WEBHOOK, {
       senderResponsePath: this.senderInformation.responsePath,
       chainId: this.chainId,
-      tokenSymbol: 'g1',
+      tokenSymbol: this.tokenSymbol,
       tokenAddress: this.tokenAddress,
       senderTgId: this.senderInformation.userTelegramID,
       senderWallet: this.senderInformation.patchwallet,

--- a/src/utils/webhooks/transaction.ts
+++ b/src/utils/webhooks/transaction.ts
@@ -44,6 +44,7 @@ export async function handleNewTransaction(params: any): Promise<boolean> {
     params.chainId,
     params.tokenAddress,
     params.chainName,
+    params.tokenSymbol,
   );
   if (!transfer) return false;
 


### PR DESCRIPTION
- [x] The `tokenSymbol` was set with a static value. Now that is beign sent the param in `new_transaction` event it can be changed to accept dynamic value.
- [x] Test refactor to check `tokenSymbol` and compared values in test for Segment.