### PR TITLE
refactor: add `updateUserOpHash` and `updateTxHash` as utils

### DIFF
--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -211,24 +211,6 @@ export class SignUpRewardTelegram {
   }
 
   /**
-   * Updates the transaction hash.
-   * @param {string} txHash - The transaction hash to be updated.
-   * @returns {string} - The updated transaction hash.
-   */
-  updateTxHash(txHash: string): string {
-    return (this.txHash = txHash);
-  }
-
-  /**
-   * Updates the user operation hash.
-   * @param {string} userOpHash - The user operation hash to be updated.
-   * @returns {string} - The updated user operation hash.
-   */
-  updateUserOpHash(userOpHash: string): string {
-    return (this.userOpHash = userOpHash);
-  }
-
-  /**
    * Saves transaction information to FlowXO.
    * @returns {Promise<void>} - The result of sending the transaction to FlowXO.
    */
@@ -483,24 +465,6 @@ export class ReferralRewardTelegram {
         newUserAddress: this.patchwallet,
       }),
     );
-  }
-
-  /**
-   * Updates the transaction hash for the referral reward.
-   * @param {string} txHash - The transaction hash to be updated.
-   * @returns {string} - The updated transaction hash.
-   */
-  updateTxHash(txHash: string): string {
-    return (this.txHash = txHash);
-  }
-
-  /**
-   * Updates the user operation hash for the referral reward.
-   * @param {string} userOpHash - The user operation hash to be updated.
-   * @returns {string} - The updated user operation hash.
-   */
-  updateUserOpHash(userOpHash: string): string {
-    return (this.userOpHash = userOpHash);
   }
 
   /**
@@ -792,24 +756,6 @@ export class LinkRewardTelegram {
   }
 
   /**
-   * Updates the transaction hash.
-   * @param {string} txHash - The transaction hash to be updated.
-   * @returns {string} - The updated transaction hash.
-   */
-  updateTxHash(txHash: string): string {
-    return (this.txHash = txHash);
-  }
-
-  /**
-   * Updates the user operation hash.
-   * @param {string} userOpHash - The user operation hash to be updated.
-   * @returns {string} - The updated user operation hash.
-   */
-  updateUserOpHash(userOpHash: string): string {
-    return (this.userOpHash = userOpHash);
-  }
-
-  /**
    * Saves transaction information to FlowXO.
    */
   async saveToFlowXO() {
@@ -1053,24 +999,6 @@ export class IsolatedRewardTelegram {
     console.log(
       `[${this.eventId}] sign up reward for ${this.userTelegramID} in MongoDB as ${status} with transaction hash : ${this.txHash}.`,
     );
-  }
-
-  /**
-   * Updates the transaction hash.
-   * @param {string} txHash - The transaction hash to be updated.
-   * @returns {string} - The updated transaction hash.
-   */
-  updateTxHash(txHash: string): string {
-    return (this.txHash = txHash);
-  }
-
-  /**
-   * Updates the user operation hash.
-   * @param {string} userOpHash - The user operation hash to be updated.
-   * @returns {string} - The updated user operation hash.
-   */
-  updateUserOpHash(userOpHash: string): string {
-    return (this.userOpHash = userOpHash);
   }
 
   /**

--- a/src/utils/transfers.ts
+++ b/src/utils/transfers.ts
@@ -383,24 +383,6 @@ export class TransferTelegram {
   }
 
   /**
-   * Updates the transaction hash.
-   * @param {string} txHash - The transaction hash to be updated.
-   * @returns {string} - The updated transaction hash.
-   */
-  updateTxHash(txHash: string): string {
-    return (this.txHash = txHash);
-  }
-
-  /**
-   * Updates the user operation hash.
-   * @param {string} userOpHash - The user operation hash to be updated.
-   * @returns {string} - The updated user operation hash.
-   */
-  updateUserOpHash(userOpHash: string): string {
-    return (this.userOpHash = userOpHash);
-  }
-
-  /**
    * Saves transaction information to the Segment.
    * @returns {Promise<void>} - The result of adding the transaction to the Segment.
    */

--- a/src/utils/webhooks/isolated-reward.ts
+++ b/src/utils/webhooks/isolated-reward.ts
@@ -7,6 +7,8 @@ import {
   getStatusRewards,
   isPendingTransactionHash,
   isTreatmentDurationExceeded,
+  updateTxHash,
+  updateUserOpHash,
 } from './utils';
 
 /**
@@ -91,7 +93,7 @@ export async function handleIsolatedReward(params: {
 
     // Update transaction hash and perform additional actions
     if (txReward && txReward.data.txHash) {
-      reward.updateTxHash(txReward.data.txHash);
+      updateTxHash(reward, txReward.data.txHash);
       await Promise.all([
         reward.updateInDatabase(TRANSACTION_STATUS.SUCCESS, new Date()),
         reward.saveToFlowXO(),
@@ -105,7 +107,7 @@ export async function handleIsolatedReward(params: {
 
     // Update userOpHash if present in txReward
     if (txReward && txReward.data.userOpHash) {
-      reward.updateUserOpHash(txReward.data.userOpHash);
+      updateUserOpHash(reward, txReward.data.userOpHash);
       await reward.updateInDatabase(TRANSACTION_STATUS.PENDING_HASH, null);
     }
     return false;

--- a/src/utils/webhooks/link-reward.ts
+++ b/src/utils/webhooks/link-reward.ts
@@ -5,6 +5,8 @@ import {
   getStatusRewards,
   isPendingTransactionHash,
   isTreatmentDurationExceeded,
+  updateTxHash,
+  updateUserOpHash,
 } from './utils';
 
 /**
@@ -59,7 +61,7 @@ export async function handleLinkReward(
       return txReward;
 
     if (txReward && txReward.data.txHash) {
-      reward.updateTxHash(txReward.data.txHash);
+      updateTxHash(reward, txReward.data.txHash);
       await Promise.all([
         reward.updateInDatabase(TRANSACTION_STATUS.SUCCESS, new Date()),
         reward.saveToFlowXO(),
@@ -73,7 +75,7 @@ export async function handleLinkReward(
 
     // Update userOpHash if present in txReward
     if (txReward && txReward.data.userOpHash) {
-      reward.updateUserOpHash(txReward.data.userOpHash);
+      updateUserOpHash(reward, txReward.data.userOpHash);
       await reward.updateInDatabase(TRANSACTION_STATUS.PENDING_HASH, null);
     }
     return false;

--- a/src/utils/webhooks/referral-reward.ts
+++ b/src/utils/webhooks/referral-reward.ts
@@ -5,6 +5,8 @@ import {
   isPendingTransactionHash,
   isSuccessfulTransaction,
   isTreatmentDurationExceeded,
+  updateTxHash,
+  updateUserOpHash,
 } from './utils';
 
 /**
@@ -86,7 +88,7 @@ export async function handleReferralReward(params: {
 
     // Update transaction hash and perform additional actions
     if (txReward && txReward.data.txHash) {
-      reward.updateTxHash(txReward.data.txHash);
+      updateTxHash(reward, txReward.data.txHash);
       await Promise.all([
         reward.updateInDatabase(TRANSACTION_STATUS.SUCCESS, new Date()),
         reward.saveToFlowXO(),
@@ -100,7 +102,7 @@ export async function handleReferralReward(params: {
 
     // Update userOpHash if present in txReward
     if (txReward && txReward.data.userOpHash) {
-      reward.updateUserOpHash(txReward.data.userOpHash);
+      updateUserOpHash(reward, txReward.data.userOpHash);
       await reward.updateInDatabase(TRANSACTION_STATUS.PENDING_HASH, null);
     }
     return false;

--- a/src/utils/webhooks/signup-reward.ts
+++ b/src/utils/webhooks/signup-reward.ts
@@ -4,6 +4,8 @@ import {
   getStatusRewards,
   isPendingTransactionHash,
   isTreatmentDurationExceeded,
+  updateTxHash,
+  updateUserOpHash,
 } from './utils';
 
 /**
@@ -71,7 +73,7 @@ export async function handleSignUpReward(params: {
 
     // Update transaction hash and perform additional actions
     if (txReward && txReward.data.txHash) {
-      reward.updateTxHash(txReward.data.txHash);
+      updateTxHash(reward, txReward.data.txHash);
       await Promise.all([
         reward.updateInDatabase(TRANSACTION_STATUS.SUCCESS, new Date()),
         reward.saveToFlowXO(),
@@ -85,7 +87,7 @@ export async function handleSignUpReward(params: {
 
     // Update userOpHash if present in txReward
     if (txReward && txReward.data.userOpHash) {
-      reward.updateUserOpHash(txReward.data.userOpHash);
+      updateUserOpHash(reward, txReward.data.userOpHash);
       await reward.updateInDatabase(TRANSACTION_STATUS.PENDING_HASH, null);
     }
     return false;

--- a/src/utils/webhooks/transaction.ts
+++ b/src/utils/webhooks/transaction.ts
@@ -7,6 +7,8 @@ import {
   isPendingTransactionHash,
   isSuccessfulTransaction,
   isTreatmentDurationExceeded,
+  updateTxHash,
+  updateUserOpHash,
 } from './utils';
 
 /**
@@ -91,7 +93,7 @@ export async function handleNewTransaction(params: {
 
   // Finalize transaction handling
   if (tx && tx.data.txHash) {
-    transfer.updateTxHash(tx.data.txHash);
+    updateTxHash(transfer, tx.data.txHash);
     await Promise.all([
       transfer.updateInDatabase(TRANSACTION_STATUS.SUCCESS, new Date()),
       transfer.saveToSegment(),
@@ -122,7 +124,7 @@ export async function handleNewTransaction(params: {
   // Handle pending hash for userOpHash
   tx &&
     tx.data.userOpHash &&
-    transfer.updateUserOpHash(tx.data.userOpHash) &&
+    updateUserOpHash(transfer, tx.data.userOpHash) &&
     (await transfer.updateInDatabase(TRANSACTION_STATUS.PENDING_HASH, null));
 
   return false;

--- a/src/utils/webhooks/utils.ts
+++ b/src/utils/webhooks/utils.ts
@@ -105,3 +105,39 @@ export async function getStatusRewards(
     return false;
   }
 }
+
+/**
+ * Updates the userOpHash property of a reward telegram instance.
+ * @param inst The reward telegram instance.
+ * @param userOpHash The user operation hash to update.
+ * @returns The updated user operation hash.
+ */
+export function updateUserOpHash(
+  inst:
+    | IsolatedRewardTelegram
+    | LinkRewardTelegram
+    | ReferralRewardTelegram
+    | SignUpRewardTelegram
+    | TransferTelegram,
+  userOpHash: string,
+): string {
+  return (inst.userOpHash = userOpHash);
+}
+
+/**
+ * Updates the txHash property of a reward telegram instance.
+ * @param inst The reward telegram instance.
+ * @param txHash The transaction hash to update.
+ * @returns The updated transaction hash.
+ */
+export function updateTxHash(
+  inst:
+    | IsolatedRewardTelegram
+    | LinkRewardTelegram
+    | ReferralRewardTelegram
+    | SignUpRewardTelegram
+    | TransferTelegram,
+  txHash: string,
+): string {
+  return (inst.txHash = txHash);
+}


### PR DESCRIPTION
This PR introduces two utility functions, updateUserOpHash and updateTxHash, designed to streamline the process of updating userOpHash and txHash properties within various reward and transfer telegram instances.

