### PR TITLE
refact: decrease hours in script when searching

### DIFF
--- a/src/scripts/bigquery.ts
+++ b/src/scripts/bigquery.ts
@@ -241,7 +241,7 @@ export const importUsersLast4Hours = async (): Promise<void> => {
   }
 
   if (!hasUsers) {
-    console.log('BIGQUERY - No users found in MongoDB in the last 24 hours.');
+    console.log('BIGQUERY - No users found in MongoDB in the last 4 hours.');
   }
 
   console.log('BIGQUERY - Import completed successfully.');
@@ -332,7 +332,7 @@ export const importTransfersLast4Hours = async (): Promise<void> => {
 
   if (!hasTransfers) {
     console.log(
-      'BIGQUERY - No transfers found in the last 24 hours in MongoDB.',
+      'BIGQUERY - No transfers found in the last 4 hours in MongoDB.',
     );
   }
 

--- a/src/scripts/bigquery.ts
+++ b/src/scripts/bigquery.ts
@@ -164,14 +164,14 @@ const importTransfers = async (): Promise<void> => {
   process.exit(0);
 };
 
-export const importUsersLast24Hours = async (): Promise<void> => {
+export const importUsersLast4Hours = async (): Promise<void> => {
   const tableId = 'users';
   const db = await Database.getInstance();
   const collection = db.collection(USERS_COLLECTION);
 
   const endDate = new Date();
   const startDate = new Date();
-  startDate.setHours(startDate.getHours() - 24);
+  startDate.setHours(startDate.getHours() - 4);
 
   const recentUsers = collection.find({
     dateAdded: { $gte: startDate, $lte: endDate },
@@ -247,7 +247,7 @@ export const importUsersLast24Hours = async (): Promise<void> => {
   console.log('BIGQUERY - Import completed successfully.');
 };
 
-export const importTransfersLast24Hours = async (): Promise<void> => {
+export const importTransfersLast4Hours = async (): Promise<void> => {
   const tableId = 'transfer';
   const db = await Database.getInstance();
   const collection = db.collection(TRANSFERS_COLLECTION);
@@ -255,7 +255,7 @@ export const importTransfersLast24Hours = async (): Promise<void> => {
   // Calculate the date 24 hours ago
   const endDate = new Date();
   const startDate = new Date();
-  startDate.setHours(startDate.getHours() - 24);
+  startDate.setHours(startDate.getHours() - 4);
 
   // Find transfers in the last 24 hours using Cursor
   const allTransfers = collection.find({

--- a/src/scripts/cronjob.ts
+++ b/src/scripts/cronjob.ts
@@ -1,28 +1,28 @@
 import cron from 'node-cron';
 import {
-  importUsersLast24Hours,
-  importTransfersLast24Hours,
+  importUsersLast4Hours,
+  importTransfersLast4Hours,
   importOrUpdateWalletUsersLast2Hours,
 } from './bigquery';
 import { distributeReferralRewards, distributeSignupRewards } from './rewards';
 
 // Schedule a task to run every hour
 cron.schedule('0 * * * *', async () => {
-  console.log('CRON - importUsersLast24Hours task');
+  console.log('CRON - importUsersLast4Hours task');
   try {
-    await importUsersLast24Hours();
+    await importUsersLast4Hours();
   } catch (error) {
-    console.log('CRON - importUsersLast24Hours error ', error);
+    console.log('CRON - importUsersLast4Hours error ', error);
   }
 });
 
 // Schedule a task to run every hour
 cron.schedule('0 * * * *', async () => {
-  console.log('CRON - importTransfersLast24Hours task');
+  console.log('CRON - importTransfersLast4Hours task');
   try {
-    await importTransfersLast24Hours();
+    await importTransfersLast4Hours();
   } catch (error) {
-    console.log('CRON - importTransfersLast24Hours error ', error);
+    console.log('CRON - importTransfersLast4Hours error ', error);
   }
 });
 


### PR DESCRIPTION
Ths PR changes the time threshold when searching `tranfers` and `users`.
The time is being reduced to not overload the servers with 24 hours time range, and with 4 hours time range even if it fails will have next 3 attempts (run every each hour).