### PR TITLE
Add Hedgey Lockups Example

### DIFF
--- a/src/routes/abi/HedgeyBatchPlanner.json
+++ b/src/routes/abi/HedgeyBatchPlanner.json
@@ -1,0 +1,179 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "recipients",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "mintType",
+        "type": "uint8"
+      }
+    ],
+    "name": "BatchCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "locker",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cliff",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rate",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BatchPlanner.Plan[]",
+        "name": "plans",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "period",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mintType",
+        "type": "uint8"
+      }
+    ],
+    "name": "batchLockingPlans",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "locker",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalAmount",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "start",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cliff",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rate",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BatchPlanner.Plan[]",
+        "name": "plans",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "period",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "vestingAdmin",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "adminTransferOBO",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint8",
+        "name": "mintType",
+        "type": "uint8"
+      }
+    ],
+    "name": "batchVestingPlans",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/types/hedgey.types.ts
+++ b/src/types/hedgey.types.ts
@@ -1,0 +1,19 @@
+export type HedgeyRecipientParams = {
+  /** The address of the recipient. */
+  recipient: string;
+  /** The amount of tokens. */
+  amount: string;
+};
+
+export type HedgeyPlanParams = {
+  /** The address of the recipient. */
+  recipient: string;
+  /** The amount of tokens. */
+  amount: string;
+  /** The start date. */
+  start: Number;
+  /** The cliff date. */
+  cliff: Number;
+  /** The rate of distribution. */
+  rate: Number;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -132,3 +132,39 @@ export const PATCHWALLET_TX_URL = 'https://paymagicapi.com/v1/kernel/tx';
  */
 export const PATCHWALLET_TX_STATUS_URL =
   'https://paymagicapi.com/v1/kernel/txStatus';
+
+
+/**
+ * Start date for the IDO.
+ */
+export const IDO_START_DATE = new Date(2024, 0, 1); // Confirm this is the date you want the plans to start unlocking
+
+/**
+ * Length of time to lock the tokens (in seconds).
+ */
+export const TOKEN_LOCK_TERM = 31536000; // 1 year, Confirm this is the length of time you want the tokens to be locked
+
+/**
+ * Default vesting admin address for Hedgey vesting locks.
+ */
+export const GRINDERY_VESTING_ADMIN = ''; // REQUIRED, multisig wallet is recommended
+
+// HEDGEY - DO NOT CHANGE THESE //
+
+/**
+ * Contract address for Hedgey Batch Planner.
+ */
+export const HEDGEY_BATCHPLANNER_ADDRESS = '0x3466EB008EDD8d5052446293D1a7D212cb65C646';
+
+/**
+ * Hedgey Locker contract for Vesting.
+ */
+export const HEDGEY_VESTING_LOCKER = '0x2CDE9919e81b20B4B33DD562a48a84b54C48F00C';
+
+/**
+ * Hedgey Locker contract for Lockups.
+ */
+export const HEDGEY_LOCKUP_LOCKER = '0x1961A23409CA59EEDCA6a99c97E4087DaD752486';
+
+// END HEDGEY - DO NOT CHANGE THESE //
+

--- a/src/utils/patchwallet.ts
+++ b/src/utils/patchwallet.ts
@@ -4,7 +4,7 @@ import {
   getClientId,
   getClientSecret,
 } from '../../secrets';
-import { getContract, scaleDecimals } from './web3';
+import { getContract, getHedgeyBatchPlannerContract, scaleDecimals } from './web3';
 import {
   DEFAULT_CHAIN_ID,
   DEFAULT_CHAIN_NAME,
@@ -13,9 +13,17 @@ import {
   PATCHWALLET_TX_STATUS_URL,
   PATCHWALLET_TX_URL,
   nativeTokenAddresses,
+  IDO_START_DATE,
+  TOKEN_LOCK_TERM,
+  HEDGEY_BATCHPLANNER_ADDRESS,
+  HEDGEY_VESTING_LOCKER,
+  HEDGEY_LOCKUP_LOCKER,
+  GRINDERY_VESTING_ADMIN
 } from './constants';
 import { PatchRawResult } from '../types/webhook.types';
+import { HedgeyRecipientParams, HedgeyPlanParams } from '../types/hedgey.types';
 import { CHAIN_NAME_MAPPING } from './chains';
+
 
 /**
  * Retrieves the Patch Wallet access token by making a POST request to the authentication endpoint.
@@ -173,6 +181,93 @@ export async function swapTokens(
       value: [value],
       data: [data],
       delegatecall: 1,
+      auth: '',
+    },
+    {
+      timeout: 100000,
+      headers: {
+        Authorization: `Bearer ${patchWalletAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+}
+
+/**
+ * Sends tokens from one wallet to another using the PayMagic API.
+ * @param {string} senderTgId - Sender's Telegram ID.
+ * @param {string} recipients - Array of Recipients.
+ * @param {string} patchWalletAccessToken - Access token for Patch Wallet API.
+ * @param {string} tokenAddress - Token address (default: G1_POLYGON_ADDRESS).
+ * @param {string} chainName - Name of the blockchain (default: 'matic').
+ * @param {string} chainId - ID of the blockchain (default: 'eip155:137').
+ * @returns {Promise<axios.AxiosResponse<PatchRawResult, AxiosError>>} - Promise resolving to the response from the PayMagic API.
+ */
+export async function hedgeyLockTokens(
+  senderTgId: string,
+  recipients: HedgeyRecipientParams[],
+  patchWalletAccessToken: string,
+  useVesting: boolean = false,
+  tokenAddress: string = G1_POLYGON_ADDRESS,
+  chainName: string = DEFAULT_CHAIN_NAME,
+  chainId: string = DEFAULT_CHAIN_ID,
+): Promise<axios.AxiosResponse<PatchRawResult, AxiosError>> {
+  // Populate the remaining fields for each plan and calculate rates
+  const startDate = Math.round(IDO_START_DATE.getTime() / 1000); // Could use Date.now() instead of constant
+  let totalAmount = 0;
+
+  const plans = recipients.map((plan) => {
+    totalAmount += Number(plan.amount);
+
+    return {
+      ...plan,
+      start: startDate,
+      cliff: startDate, // No cliff
+      rate: Math.ceil(Number(plan.amount) / TOKEN_LOCK_TERM), // Rate is tokens unlocked per second
+    } as HedgeyPlanParams
+  });
+
+  // Determine data, value, and address based on vesting or lockup
+  const [data, value, address] = [
+    useVesting ? [
+          getHedgeyBatchPlannerContract(chainId)
+            .methods['batchVestingPlans'](
+              HEDGEY_VESTING_LOCKER,
+              tokenAddress,
+              totalAmount,
+              plans,
+              1, // Period: Linear
+              GRINDERY_VESTING_ADMIN,
+              true,
+              4 // Vesting (fixed Hedgey constant)
+            )
+            .encodeABI(),
+        ] : [
+          getHedgeyBatchPlannerContract(chainId)
+            .methods['batchLockingPlans'](
+              HEDGEY_LOCKUP_LOCKER,
+              tokenAddress,
+              totalAmount,
+              plans,
+              1, // Period: Linear
+              5 // Investor Lockups (fixed Hedgey constant)
+            )
+            .encodeABI(),
+        ],
+        ['0x00'],
+        HEDGEY_BATCHPLANNER_ADDRESS,
+      ];
+
+  // Lock the tokens using PayMagic API
+  return await axios.post(
+    PATCHWALLET_TX_URL,
+    {
+      userId: `grindery:${senderTgId}`,
+      chain: chainName,
+      to: [address],
+      value: value,
+      data: data,
+      delegatecall: 0,
       auth: '',
     },
     {

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -1,6 +1,7 @@
 import { G1_POLYGON_ADDRESS } from '../../secrets';
 import { CHAIN_MAPPING } from './chains';
 import ERC20 from '../routes/abi/ERC20.json';
+import HedgeyBatchPlanner from '../routes/abi/HedgeyBatchPlanner.json';
 import Web3 from 'web3';
 import BN from 'bn.js';
 import { Contract } from 'web3-eth-contract';
@@ -112,4 +113,22 @@ export function scaleDecimals(etherInput: string, decimals: number): string {
       ? new BN(whole).mul(base).add(new BN(fraction)).mul(new BN(-1))
       : new BN(whole).mul(base).add(new BN(fraction))
   ).toString(10);
+}
+
+/**
+ * Creates and returns a contract instance of the Hedgey Batch Planner.
+ * @param {string} chainId - Chain ID (default: 'eip155:137').
+ * @returns {Contract} - Web3 contract instance.
+ * @throws {Error} - Throws an error if the chainId is invalid.
+ */
+export function getHedgeyBatchPlannerContract(
+  chainId: string = DEFAULT_CHAIN_ID
+): Contract {
+  if (!CHAIN_MAPPING[chainId]) {
+    throw new Error('Invalid chain: ' + chainId);
+  }
+
+  return new new Web3(CHAIN_MAPPING[chainId][1]).eth.Contract(
+    HedgeyBatchPlanner as AbiItem[]
+  );
 }


### PR DESCRIPTION
This adds a new `hedgeyLockTokens` method that allows creating Hedgey Vesting or Hedgey Lockup plans.

There are 3 constants that need to be set,
**IDO_START_DATE** The start date for the unlock. If you'd rather the start date be set to when the plan is minted you can use Date.now() instead in the `hedgeyLockTokens` method.
**TOKEN_LOCK_TERM** Time in seconds you want for the length of the plans. Set to 1 year by default.
**GRINDERY_VESTING_ADMIN** This is the address you want set as the Vesting Admin (able to revoke/transfer plans). Highly recommend this to be a multisig. 

The other 3 constants should not be touched, they are the Hedgey contracts. All of our supported mainnets use these same addresses. 

Happy to hop on a call if you need any clarification on anything.