### PR TITLE
type: add a type for Contract Stubs

### DIFF
--- a/src/test/pubsub-isolated-reward.test.ts
+++ b/src/test/pubsub-isolated-reward.test.ts
@@ -14,6 +14,7 @@ import {
   getCollectionUsersMock,
   getCollectionRewardsMock,
   mockChainId,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -44,7 +45,7 @@ describe('handleIsolatedReward function', async function () {
   let axiosStub;
   let rewardId: string;
   let collectionRewardsMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-link-reward.test.ts
+++ b/src/test/pubsub-link-reward.test.ts
@@ -14,6 +14,7 @@ import {
   getCollectionUsersMock,
   getCollectionRewardsMock,
   mockChainId,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -40,7 +41,7 @@ describe('handleLinkReward function', async function () {
   let rewardId: string;
   let collectionUsersMock: Collection<Document>;
   let collectionRewardsMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-new-transaction.test.ts
+++ b/src/test/pubsub-new-transaction.test.ts
@@ -14,6 +14,7 @@ import {
   mockChainId,
   getCollectionUsersMock,
   getCollectionTransfersMock,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -45,7 +46,7 @@ describe('handleNewTransaction function', async function () {
   let txId: string;
   let collectionUsersMock: Collection<Document>;
   let collectionTransfersMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-new-vesting.test.ts
+++ b/src/test/pubsub-new-vesting.test.ts
@@ -14,6 +14,7 @@ import {
   getCollectionUsersMock,
   getCollectionVestingsMock,
   mockWallet1,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -41,7 +42,7 @@ describe('handleNewVesting function', async function () {
   let txId: string;
   let collectionUsersMock: Collection<Document>;
   let collectionVestingsMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-referral-reward.test.ts
+++ b/src/test/pubsub-referral-reward.test.ts
@@ -32,6 +32,7 @@ import {
   getCollectionUsersMock,
   getCollectionRewardsMock,
   mockChainId,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -64,7 +65,7 @@ describe('handleReferralReward function', function () {
   let collectionTransfersMock: Collection<Document>;
   let collectionUsersMock: Collection<Document>;
   let collectionRewardsMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-reward.test.ts
+++ b/src/test/pubsub-reward.test.ts
@@ -7,6 +7,7 @@ import {
   mockWallet,
   mockUserTelegramID1,
   getCollectionUsersMock,
+  ContractStub,
 } from './utils';
 import { handleNewReward } from '../webhooks/webhook';
 import Sinon from 'sinon';
@@ -41,7 +42,7 @@ describe('handleReferralReward function', function () {
   let linkRewardStub: Sinon.SinonStub<[params: RewardParams], Promise<boolean>>;
   let eventId: string;
   let collectionUsersMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-signup-reward.test.ts
+++ b/src/test/pubsub-signup-reward.test.ts
@@ -13,6 +13,7 @@ import {
   getCollectionUsersMock,
   getCollectionRewardsMock,
   mockChainId,
+  ContractStub,
 } from './utils';
 import { handleSignUpReward } from '../webhooks/signup-reward';
 import Sinon from 'sinon';
@@ -43,7 +44,7 @@ describe('handleSignUpReward function', async function () {
   let rewardId: string;
   let collectionUsersMock: Collection<Document>;
   let collectionRewardsMock: Collection<Document>;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {

--- a/src/test/pubsub-swap.test.ts
+++ b/src/test/pubsub-swap.test.ts
@@ -23,6 +23,7 @@ import {
   getCollectionUsersMock,
   getCollectionSwapsMock,
   mockValue,
+  ContractStub,
 } from './utils';
 import Sinon from 'sinon';
 import axios from 'axios';
@@ -113,7 +114,7 @@ describe('handleSwap function', async function () {
   });
 
   describe('Normal process to handle a swap', async function () {
-    let contractStub: { methods: any };
+    let contractStub: ContractStub;
     let getContract;
 
     beforeEach(async function () {
@@ -1572,7 +1573,7 @@ describe('handleSwap function', async function () {
     });
 
     describe('Transaction hash is present in PatchWallet status endpoint', async function () {
-      let contractStub: { methods: any };
+      let contractStub: ContractStub;
       let getContract;
 
       beforeEach(async function () {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -149,3 +149,16 @@ async function getAccessToken(): Promise<string> {
  * Mocked token retrieved as an access token.
  */
 export const mockedToken = getAccessToken();
+
+/**
+ * Represents a smart contract stub with methods of any type.
+ * This type is used to define an object structure containing contract methods.
+ */
+export type ContractStub = {
+  /**
+   * Methods within the contract.
+   * Type: any
+   * This property holds the methods associated with the contract, allowing flexibility in method definitions.
+   */
+  methods: any;
+};

--- a/src/test/vesting.test.ts
+++ b/src/test/vesting.test.ts
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import { getData, getPlans } from '../utils/vesting';
-import { mockTokenAddress, mockWallet } from './utils';
+import { ContractStub, mockTokenAddress, mockWallet } from './utils';
 import { HedgeyPlanParams } from '../types/hedgey.types';
 import { DEFAULT_CHAIN_ID, IDO_START_DATE } from '../utils/constants';
 import Sinon from 'sinon';
@@ -8,7 +8,7 @@ import * as web3 from '../utils/web3';
 
 describe('Vesting functions', async function () {
   let sandbox: Sinon.SinonSandbox;
-  let contractStub: { methods: any };
+  let contractStub: ContractStub;
   let getContract;
 
   beforeEach(async function () {


### PR DESCRIPTION
This pull request introduces a new type, `ContractStub`, providing a structured representation for contract stubs within the codebase. The `ContractStub` type encapsulates contract methods, allowing for clearer definition and maintenance of contract-related structures.

