### PR TITLE
feat: add new 503 failure code in database for transactions and swaps

### DIFF
--- a/src/test/pubsub-new-transaction.test.ts
+++ b/src/test/pubsub-new-transaction.test.ts
@@ -632,6 +632,93 @@ describe('handleNewTransaction function', async function () {
     });
   });
 
+  describe('Transaction if is already a failure 503', async function () {
+    beforeEach(async function () {
+      await collectionUsersMock.insertOne({
+        userTelegramID: mockUserTelegramID,
+        userName: mockUserName,
+        userHandle: mockUserHandle,
+        patchwallet: mockWallet,
+      });
+
+      await collectionTransfersMock.insertOne({
+        eventId: txId,
+        status: TRANSACTION_STATUS.FAILURE_503,
+      });
+    });
+
+    it('Should return true and no token sending if transaction if is already a failure', async function () {
+      chai.expect(
+        await handleNewTransaction({
+          senderTgId: mockUserTelegramID,
+          amount: '100',
+          recipientTgId: mockUserTelegramID1,
+          eventId: txId,
+        }),
+      ).to.be.true;
+    });
+
+    it('Should not send tokens if transaction if is already a failure', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(
+        axiosStub.getCalls().find((e) => e.firstArg === PATCHWALLET_TX_URL),
+      ).to.be.undefined;
+    });
+
+    it('Should not modify database if transaction if is already a failure', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai
+        .expect(await collectionTransfersMock.find({}).toArray())
+        .excluding(['_id'])
+        .to.deep.equal([
+          {
+            eventId: txId,
+            status: TRANSACTION_STATUS.FAILURE_503,
+          },
+        ]);
+    });
+
+    it('Should not call FlowXO if is already a failure', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(
+        axiosStub
+          .getCalls()
+          .find((e) => e.firstArg === FLOWXO_NEW_TRANSACTION_WEBHOOK),
+      ).to.be.undefined;
+    });
+
+    it('Should not call Segment if is already a failure', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(
+        axiosStub.getCalls().find((e) => e.firstArg === SEGMENT_TRACK_URL),
+      ).to.be.undefined;
+    });
+  });
+
   describe('Error in send token request', async function () {
     beforeEach(async function () {
       await collectionUsersMock.insertOne({
@@ -1102,6 +1189,94 @@ describe('handleNewTransaction function', async function () {
     });
 
     it('Should not call Segment if error 470 in PatchWallet transaction', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(
+        axiosStub.getCalls().find((e) => e.firstArg === SEGMENT_TRACK_URL),
+      ).to.be.undefined;
+    });
+  });
+
+  describe('PatchWallet 503 error', async function () {
+    beforeEach(async function () {
+      axiosStub.withArgs(PATCHWALLET_TX_URL).rejects({
+        response: {
+          status: 503,
+        },
+      });
+
+      await collectionUsersMock.insertOne({
+        userTelegramID: mockUserTelegramID,
+        userName: mockUserName,
+        userHandle: mockUserHandle,
+        patchwallet: mockWallet,
+        responsePath: mockResponsePath,
+      });
+    });
+
+    it('Should return true if error 503 in PatchWallet transaction', async function () {
+      const result = await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(result).to.be.true;
+    });
+
+    it('Should complete db status to failure 503 in database if error 503 in PatchWallet transaction', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai
+        .expect(await collectionTransfersMock.find({}).toArray())
+        .excluding(['dateAdded', '_id'])
+        .to.deep.equal([
+          {
+            eventId: txId,
+            chainId: mockChainId,
+            tokenSymbol: G1_TOKEN_SYMBOL,
+            tokenAddress: G1_POLYGON_ADDRESS,
+            senderTgId: mockUserTelegramID,
+            senderWallet: mockWallet,
+            senderName: mockUserName,
+            senderHandle: mockUserHandle,
+            recipientTgId: mockUserTelegramID1,
+            recipientWallet: mockWallet,
+            tokenAmount: '100',
+            status: TRANSACTION_STATUS.FAILURE_503,
+            transactionHash: null,
+            userOpHash: null,
+          },
+        ]);
+    });
+
+    it('Should not call FlowXO if error 503 in PatchWallet transaction', async function () {
+      await handleNewTransaction({
+        senderTgId: mockUserTelegramID,
+        amount: '100',
+        recipientTgId: mockUserTelegramID1,
+        eventId: txId,
+      });
+
+      chai.expect(
+        axiosStub
+          .getCalls()
+          .find((e) => e.firstArg === FLOWXO_NEW_TRANSACTION_WEBHOOK),
+      ).to.be.undefined;
+    });
+
+    it('Should not call Segment if error 503 in PatchWallet transaction', async function () {
       await handleNewTransaction({
         senderTgId: mockUserTelegramID,
         amount: '100',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -78,6 +78,7 @@ export const TRANSACTION_STATUS = {
   SUCCESS: 'success',
   FAILURE: 'failure',
   PENDING_HASH: 'pending_hash',
+  FAILURE_503: 'failure_503',
 } as const;
 
 /**

--- a/src/utils/swap.ts
+++ b/src/utils/swap.ts
@@ -289,16 +289,25 @@ export class SwapTelegram {
       console.error(
         `[${this.params.eventId}] Error processing PatchWallet swap for user telegram id [${this.params.userTelegramID}]: ${error.message}`,
       );
-      // Return true if the amount is not a valid number or the error status is 470, marking the transaction as failed
-      return !/^\d+$/.test(this.params.value) ||
+      // Check for potential invalid amount or specific error responses
+      if (
+        !/^\d+$/.test(this.params.value) ||
         error?.response?.status === 470 ||
         error?.response?.status === 400
-        ? (console.warn(
-            `Potentially invalid amount: ${this.params.amount}, dropping`,
-          ),
-          await this.updateInDatabase(TRANSACTION_STATUS.FAILURE, new Date()),
-          { isError: true })
-        : { isError: false };
+      ) {
+        console.warn(
+          `Potentially invalid amount: ${this.params.amount}, dropping`,
+        );
+        await this.updateInDatabase(TRANSACTION_STATUS.FAILURE, new Date());
+        return { isError: true };
+      }
+      // Handling specific error response status 503
+      if (error?.response?.status === 503) {
+        await this.updateInDatabase(TRANSACTION_STATUS.FAILURE_503, new Date());
+        return { isError: true };
+      }
+      // Return PatchResult indicating no error if not handled specifically
+      return { isError: false };
     }
   }
 }

--- a/src/utils/transfers.ts
+++ b/src/utils/transfers.ts
@@ -557,15 +557,24 @@ export class TransferTelegram {
       console.error(
         `[${this.eventId}] transaction from ${this.params.senderInformation.userTelegramID} to ${this.params.recipientTgId} for ${this.params.amount} - Error processing PatchWallet token sending: ${error}`,
       );
-      // Return true if the amount is not a valid number or the error status is 470, marking the transaction as failed
-      return !isPositiveFloat(this.params.amount) ||
+      // Check for potential invalid amount or specific error responses
+      if (
+        !isPositiveFloat(this.params.amount) ||
         error?.response?.status === 470
-        ? (console.warn(
-            `Potentially invalid amount: ${this.params.amount}, dropping`,
-          ),
-          await this.updateInDatabase(TRANSACTION_STATUS.FAILURE, new Date()),
-          { isError: true })
-        : { isError: false };
+      ) {
+        console.warn(
+          `Potentially invalid amount: ${this.params.amount}, dropping`,
+        );
+        await this.updateInDatabase(TRANSACTION_STATUS.FAILURE, new Date());
+        return { isError: true };
+      }
+      // Handling specific error response status 503
+      if (error?.response?.status === 503) {
+        await this.updateInDatabase(TRANSACTION_STATUS.FAILURE_503, new Date());
+        return { isError: true };
+      }
+      // Return PatchResult indicating no error if not handled specifically
+      return { isError: false };
     }
   }
 }

--- a/src/webhooks/utils.ts
+++ b/src/webhooks/utils.ts
@@ -23,7 +23,10 @@ export function isSuccessfulTransaction(status: TransactionStatus): boolean {
  * @returns {boolean} - True if the transaction has failed, false otherwise.
  */
 export function isFailedTransaction(status: TransactionStatus): boolean {
-  return status === TRANSACTION_STATUS.FAILURE;
+  return (
+    status === TRANSACTION_STATUS.FAILURE ||
+    status === TRANSACTION_STATUS.FAILURE_503
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

This pull request introduces a new feature to enhance the error handling mechanism for transactions and swaps. It includes the addition of a specific failure code, 503 from PatchWallet, in the database to accurately capture and manage error cases related to service unavailable responses.

 Incorporating this new failure code will provide better insight into and management of these specific failure scenarios during transactions and swaps.

