### PR TITLE
feat: add routes for tge pre order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
           TEST_ENV: ${{ secrets.TEST_ENV }}
           GRINDERY_NEXUS_REFRESH_TOKEN: ${{ secrets.GRINDERY_NEXUS_REFRESH_TOKEN }}
           FLOWXO_NEW_VESTING_WEBHOOK: ${{ secrets.FLOWXO_NEW_VESTING_WEBHOOK }}
+          API_KEY: ${{ secrets.API_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "bignumber.js": "^9.1.1",
         "body-parser": "^1.20.2",
         "chai-exclude": "^2.1.0",
+        "chai-http": "^4.4.0",
         "csv-parser": "^3.0.0",
         "csv-writer": "^1.6.0",
         "dotenv": "^16.3.1",
@@ -3608,8 +3609,7 @@
     "node_modules/@types/chai": {
       "version": "4.3.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
-      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
-      "dev": true
+      "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ=="
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -3619,6 +3619,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="
     },
     "node_modules/@types/duplexify": {
       "version": "3.6.4",
@@ -3848,6 +3853,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz",
+      "integrity": "sha512-YIGelp3ZyMiH0/A09PMAORO0EBGlF5xIKfDpK74wdYvWUs2o96b5CItJcWPdH409b7SAXIIG6p8NdU/4U2Maww==",
+      "dependencies": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -4272,6 +4286,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -4947,6 +4966,38 @@
         "chai": ">= 4.0.0 < 5"
       }
     },
+    "node_modules/chai-http": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.4.0.tgz",
+      "integrity": "sha512-uswN3rZpawlRaa5NiDUHcDZ3v2dw5QgLyAwnQ2tnVNuP7CwIsOFuYJ0xR1WiR7ymD4roBnJIzOUep7w9jQMFJA==",
+      "dependencies": {
+        "@types/chai": "4",
+        "@types/superagent": "4.1.13",
+        "charset": "^1.0.1",
+        "cookiejar": "^2.1.4",
+        "is-ip": "^2.0.0",
+        "methods": "^1.1.2",
+        "qs": "^6.11.2",
+        "superagent": "^8.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chai-http/node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4970,6 +5021,14 @@
       "peer": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/charset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
+      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/check-error": {
@@ -5164,6 +5223,14 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5217,6 +5284,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -5515,6 +5587,15 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -6379,6 +6460,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
@@ -6659,6 +6745,20 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
       "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
+    "node_modules/formidable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -7154,6 +7254,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7411,6 +7519,14 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
+    "node_modules/ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7548,6 +7664,17 @@
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+      "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
+      "dependencies": {
+        "ip-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-number": {
@@ -11110,6 +11237,37 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bignumber.js": "^9.1.1",
     "body-parser": "^1.20.2",
     "chai-exclude": "^2.1.0",
+    "chai-http": "^4.4.0",
     "csv-parser": "^3.0.0",
     "csv-writer": "^1.6.0",
     "dotenv": "^16.3.1",

--- a/src/routes/tge.ts
+++ b/src/routes/tge.ts
@@ -1,6 +1,15 @@
 import express from 'express';
 import { authenticateApiKey } from '../utils/auth';
-import { computeG1ToGxConversion } from '../utils/g1gx';
+import { EXCHANGE_RATE_G1_USD, computeG1ToGxConversion } from '../utils/g1gx';
+import { Database } from '../db/conn';
+import {
+  GX_ORDER_COLLECTION,
+  GX_QUOTE_COLLECTION,
+  GX_ORDER_STATUS,
+} from '../utils/constants';
+import { v4 as uuidv4 } from 'uuid';
+import { getPatchWalletAccessToken, sendTokens } from '../utils/patchwallet';
+import { SOURCE_WALLET_ADDRESS } from '../../secrets';
 
 const router = express.Router();
 
@@ -43,14 +52,194 @@ const router = express.Router();
  */
 router.get('/conversion-information', authenticateApiKey, async (req, res) => {
   try {
+    const result = computeG1ToGxConversion(
+      Number(req.query.usdQuantity),
+      Number(req.query.g1Quantity),
+      4,
+    );
+
+    const db = await Database.getInstance();
+
+    const id = uuidv4();
+
+    await db.collection(GX_QUOTE_COLLECTION).updateOne(
+      { quoteId: id },
+      {
+        $set: {
+          ...result,
+          quoteId: id,
+          date: new Date(),
+          userTelegramID: req.query.userTelegramID,
+        },
+      },
+      { upsert: true },
+    );
+
+    return res.status(200).json(result);
+  } catch (error) {
+    return res.status(500).json({ msg: 'An error occurred', error });
+  }
+});
+
+/**
+ * POST /v1/tge/pre-order
+ *
+ * @summary Create a Gx token pre-order
+ * @description Initiates a pre-order for Gx tokens based on the provided quote ID and user details.
+ * @tags Pre-Order
+ * @security BearerAuth
+ * @param {string} req.body.quoteId - The quote ID to create a pre-order.
+ * @param {string} req.body.userTelegramID - The user's Telegram ID for identification.
+ * @return {object} 200 - Success response with the pre-order transaction details
+ * @return {object} 400 - Error response if a quote is unavailable or the order is being processed
+ * @return {object} 500 - Error response if an error occurs during the pre-order process
+ */
+router.post('/pre-order', authenticateApiKey, async (req, res) => {
+  const db = await Database.getInstance();
+
+  // Retrieve quote details based on the provided quoteId
+  const quote = await db
+    .collection(GX_QUOTE_COLLECTION)
+    .findOne({ quoteId: req.body.quoteId });
+
+  // If quote is not found, return an error response
+  if (!quote)
+    return res.status(400).json({ msg: 'No quote available for this ID' });
+
+  // Check if an order with the same quoteId is already being processed
+  const order = await db
+    .collection(GX_ORDER_COLLECTION)
+    .findOne({ orderId: req.body.quoteId });
+
+  // If an order is already being processed, return an error response
+  if (order && order.status !== GX_ORDER_STATUS.FAILURE)
+    return res
+      .status(400)
+      .json({ msg: 'This order is already being processed' });
+
+  // Calculate the G1 amount for the pre-order
+  const g1_amount = (
+    Number(quote.usd_from_g1_holding) * EXCHANGE_RATE_G1_USD
+  ).toFixed(2);
+
+  // Create/update the pre-order with pending status and user details
+  await db.collection(GX_ORDER_COLLECTION).updateOne(
+    { orderId: req.body.quoteId },
+    {
+      $set: {
+        orderId: req.body.quoteId,
+        date: new Date(),
+        status: GX_ORDER_STATUS.PENDING,
+        userTelegramID: req.body.userTelegramID,
+        g1_amount,
+      },
+    },
+    { upsert: true },
+  );
+
+  try {
+    // Send tokens for the pre-order and get transaction details
+    const { data } = await sendTokens(
+      req.body.userTelegramID,
+      SOURCE_WALLET_ADDRESS,
+      g1_amount,
+      await getPatchWalletAccessToken(),
+      0,
+    );
+
+    // Determine the status of the pre-order based on additional conditions
+    const status =
+      Number(quote.usd_from_usd_investment) > 0
+        ? GX_ORDER_STATUS.PENDING_USD
+        : GX_ORDER_STATUS.COMPLETE;
+
+    // Update the pre-order with transaction details and updated status
+    await db.collection(GX_ORDER_COLLECTION).updateOne(
+      { orderId: req.body.quoteId },
+      {
+        $set: {
+          orderId: req.body.quoteId,
+          date: new Date(),
+          status,
+          userTelegramID: req.body.userTelegramID,
+          g1_amount,
+          transactionHash: data.txHash,
+          userOpHash: data.userOpHash,
+        },
+      },
+      { upsert: true },
+    );
+
+    // Return success response with pre-order transaction details
+    return res
+      .status(200)
+      .json({ success: true, transactionHash: data.txHash });
+  } catch (e) {
+    // Log error if transaction fails and update pre-order status to failure
+    console.error(
+      `[${req.body.quoteId}] Error processing PatchWallet pre-order G1 transaction: ${e}`,
+    );
+
+    await db.collection(GX_ORDER_COLLECTION).updateOne(
+      { orderId: req.body.quoteId },
+      {
+        $set: {
+          orderId: req.body.quoteId,
+          date: new Date(),
+          status: GX_ORDER_STATUS.FAILURE,
+          userTelegramID: req.body.userTelegramID,
+          g1_amount,
+        },
+      },
+      { upsert: true },
+    );
+
+    // Return error response if an error occurs during the pre-order process
+    return res.status(500).json({ msg: 'An error occurred', e });
+  }
+});
+
+/**
+ * GET /v1/tge/order-status
+ *
+ * @summary Get the status of a Gx token order
+ * @description Retrieves the status of a Gx token order based on the order ID.
+ * @tags Order Status
+ * @security BearerAuth
+ * @param {string} req.query.orderId - The order ID to fetch the status.
+ * @return {object} 200 - Success response with the order status details
+ * @return {object} 500 - Error response if an error occurs during status retrieval
+ *
+ * @example request - 200 - Example request query parameter
+ * /v1/tge/order-status?orderId=mocked-order-id
+ *
+ * @example response - 200 - Success response example
+ * {
+ *   "orderId": "mocked-order-id",
+ *   "date": "2023-12-31T12:00:00Z",
+ *   "status": "PENDING",
+ *   "userTelegramID": "user-telegram-id",
+ *   "g1_amount": "50.00",
+ *   "transactionHash": "transaction-hash",
+ *   "userOpHash": "user-operation-hash"
+ * }
+ *
+ * @example response - 500 - Error response example
+ * {
+ *   "msg": "An error occurred",
+ *   "error": "Error details here"
+ * }
+ */
+router.get('/order-status', authenticateApiKey, async (req, res) => {
+  try {
+    const db = await Database.getInstance();
+
     return res
       .status(200)
       .json(
-        computeG1ToGxConversion(
-          Number(req.query.usdQuantity),
-          Number(req.query.g1Quantity),
-          4,
-        ),
+        await db
+          .collection(GX_ORDER_COLLECTION)
+          .findOne({ orderId: req.query.orderId }),
       );
   } catch (error) {
     return res.status(500).json({ msg: 'An error occurred', error });

--- a/src/test/tge.test.ts
+++ b/src/test/tge.test.ts
@@ -1,0 +1,428 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import Sinon from 'sinon';
+import * as g1gx from '../utils/g1gx';
+import app from '../index';
+import { getApiKey } from '../../secrets';
+import {
+  getCollectionGXOrderMock,
+  getCollectionGXQuoteMock,
+  isUUIDv4,
+  mockAccessToken,
+  mockChainName,
+  mockOrderID,
+  mockOrderID1,
+  mockTokenAddress,
+  mockTransactionHash,
+  mockUserOpHash,
+  mockUserTelegramID,
+  mockWallet,
+} from './utils';
+import chaiExclude from 'chai-exclude';
+import {
+  PATCHWALLET_AUTH_URL,
+  PATCHWALLET_RESOLVER_URL,
+  PATCHWALLET_TX_STATUS_URL,
+  PATCHWALLET_TX_URL,
+  GX_ORDER_STATUS,
+} from '../utils/constants';
+import axios from 'axios';
+
+chai.use(chaiHttp);
+chai.use(chaiExclude);
+
+describe('G1 to GX util functions', async function () {
+  let sandbox: Sinon.SinonSandbox;
+  let collectionQuotesMock;
+  let collectionOrdersMock;
+  let axiosStub;
+
+  beforeEach(async function () {
+    collectionQuotesMock = await getCollectionGXQuoteMock();
+    collectionOrdersMock = await getCollectionGXOrderMock();
+
+    sandbox = Sinon.createSandbox();
+    sandbox.stub(g1gx, 'computeG1ToGxConversion').returns({
+      usd_from_usd_investment: '1',
+      usd_from_g1_holding: '1',
+      usd_from_mvu: '1',
+      usd_from_time: '1',
+      equivalent_usd_invested: '1',
+      gx_before_mvu: '1',
+      gx_mvu_effect: '1',
+      gx_time_effect: '1',
+      equivalent_gx_usd_exchange_rate: '1',
+      standard_gx_usd_exchange_rate: '1',
+      discount_received: '1',
+      gx_received: '1',
+    });
+
+    axiosStub = sandbox.stub(axios, 'post').callsFake(async (url: string) => {
+      if (url === PATCHWALLET_AUTH_URL) {
+        return Promise.resolve({
+          data: {
+            access_token: mockAccessToken,
+          },
+        });
+      }
+
+      if (url === PATCHWALLET_TX_URL) {
+        return Promise.resolve({
+          data: {
+            txHash: mockTransactionHash,
+            userOpHash: mockUserOpHash,
+          },
+        });
+      }
+
+      if (url === PATCHWALLET_RESOLVER_URL) {
+        return Promise.resolve({
+          data: {
+            users: [{ accountAddress: mockWallet }],
+          },
+        });
+      }
+
+      if (url === PATCHWALLET_TX_STATUS_URL) {
+        return Promise.resolve({
+          data: {
+            txHash: mockTransactionHash,
+            userOpHash: mockUserOpHash,
+          },
+        });
+      }
+
+      throw new Error('Unexpected URL encountered');
+    });
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('Endpoint for conversion information', async function () {
+    it('Should return all conversion information', async function () {
+      const res = await chai
+        .request(app)
+        .get('/v1/tge/conversion-information')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .query({
+          usdQuantity: '10',
+          g1Quantity: '4',
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai.expect(res.body).to.deep.equal({
+        usd_from_usd_investment: '1',
+        usd_from_g1_holding: '1',
+        usd_from_mvu: '1',
+        usd_from_time: '1',
+        equivalent_usd_invested: '1',
+        gx_before_mvu: '1',
+        gx_mvu_effect: '1',
+        gx_time_effect: '1',
+        equivalent_gx_usd_exchange_rate: '1',
+        standard_gx_usd_exchange_rate: '1',
+        discount_received: '1',
+        gx_received: '1',
+      });
+    });
+
+    it('Should fill the quote database with a quote ID and conversion informations', async function () {
+      await chai
+        .request(app)
+        .get('/v1/tge/conversion-information')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .query({
+          usdQuantity: '10',
+          g1Quantity: '4',
+          userTelegramID: mockUserTelegramID,
+        });
+
+      const quotes = await collectionQuotesMock.find({}).toArray();
+
+      chai
+        .expect(quotes)
+        .excluding(['_id', 'date', 'quoteId'])
+        .to.deep.equal([
+          {
+            usd_from_usd_investment: '1',
+            usd_from_g1_holding: '1',
+            usd_from_mvu: '1',
+            usd_from_time: '1',
+            equivalent_usd_invested: '1',
+            gx_before_mvu: '1',
+            gx_mvu_effect: '1',
+            gx_time_effect: '1',
+            equivalent_gx_usd_exchange_rate: '1',
+            standard_gx_usd_exchange_rate: '1',
+            discount_received: '1',
+            gx_received: '1',
+            userTelegramID: mockUserTelegramID,
+          },
+        ]);
+
+      chai.expect(isUUIDv4(quotes[0].quoteId)).to.be.true;
+    });
+  });
+
+  describe('Endpoint to catch the order status', async function () {
+    beforeEach(async function () {
+      await collectionOrdersMock.insertOne({
+        orderId: mockOrderID,
+        status: GX_ORDER_STATUS.COMPLETE,
+      });
+    });
+
+    it('Should return the order status if orderId is present in database', async function () {
+      const res = await chai
+        .request(app)
+        .get('/v1/tge/order-status')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .query({
+          orderId: mockOrderID,
+        });
+
+      chai.expect(res.body).excluding(['_id']).to.deep.equal({
+        orderId: mockOrderID,
+        status: GX_ORDER_STATUS.COMPLETE,
+      });
+    });
+
+    it('Should return an empty result if orderId is not present in database', async function () {
+      const res = await chai
+        .request(app)
+        .get('/v1/tge/order-status')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .query({
+          orderId: 'another_order_ID',
+        });
+
+      chai.expect(res.body).to.be.equal(null);
+    });
+  });
+
+  describe('Endpoint to do preorder', async function () {
+    beforeEach(async function () {
+      await collectionQuotesMock.insertMany([
+        {
+          quoteId: mockOrderID,
+          usd_from_usd_investment: '1',
+          usd_from_g1_holding: '1',
+          usd_from_mvu: '1',
+          usd_from_time: '1',
+          equivalent_usd_invested: '1',
+          gx_before_mvu: '1',
+          gx_mvu_effect: '1',
+          gx_time_effect: '1',
+          equivalent_gx_usd_exchange_rate: '1',
+          standard_gx_usd_exchange_rate: '1',
+          discount_received: '1',
+          gx_received: '1',
+          userTelegramID: mockUserTelegramID,
+        },
+        {
+          quoteId: mockOrderID1,
+          usd_from_usd_investment: '0',
+          usd_from_g1_holding: '1',
+          usd_from_mvu: '1',
+          usd_from_time: '1',
+          equivalent_usd_invested: '1',
+          gx_before_mvu: '1',
+          gx_mvu_effect: '1',
+          gx_time_effect: '1',
+          equivalent_gx_usd_exchange_rate: '1',
+          standard_gx_usd_exchange_rate: '1',
+          discount_received: '1',
+          gx_received: '1',
+          userTelegramID: mockUserTelegramID,
+        },
+      ]);
+    });
+
+    it('Should return an error message if no quote available for the given quote ID', async function () {
+      const res = await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: 'non_existing_quote_id',
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai
+        .expect(res.body)
+        .to.deep.equal({ msg: 'No quote available for this ID' });
+    });
+
+    it('Should return an error message if order is pending', async function () {
+      await collectionOrdersMock.insertOne({
+        orderId: mockOrderID,
+        status: GX_ORDER_STATUS.PENDING,
+      });
+
+      const res = await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai
+        .expect(res.body)
+        .to.deep.equal({ msg: 'This order is already being processed' });
+    });
+
+    it('Should return an error message if order is success', async function () {
+      await collectionOrdersMock.insertOne({
+        orderId: mockOrderID,
+        status: GX_ORDER_STATUS.COMPLETE,
+      });
+
+      const res = await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai
+        .expect(res.body)
+        .to.deep.equal({ msg: 'This order is already being processed' });
+    });
+
+    it('Should call the sendTokens properly if order is not present in database', async function () {
+      await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai
+        .expect(
+          axiosStub.getCalls().find((e) => e.firstArg === PATCHWALLET_TX_URL)
+            .args[1],
+        )
+        .to.deep.equal({
+          userId: `grindery:${mockUserTelegramID}`,
+          chain: mockChainName,
+          to: [mockTokenAddress],
+          value: ['0x00'],
+          data: [
+            '0xa9059cbb0000000000000000000000006ef802abd3108411afe86656c9a369946aff590d00000000000000000000000000000000000000000000003635c9adc5dea00000',
+          ],
+          delegatecall: 0,
+          auth: '',
+        });
+    });
+
+    it('Should return the transaction hash if order is not present in database', async function () {
+      const res = await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      chai
+        .expect(res.body)
+        .to.deep.equal({ success: true, transactionHash: mockTransactionHash });
+    });
+
+    it('Should update the database with a pending USD status if order is not present in database and USD amount is positive', async function () {
+      await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      const orders = await collectionOrdersMock.find({}).toArray();
+
+      chai
+        .expect(orders)
+        .excluding(['_id', 'date'])
+        .to.deep.equal([
+          {
+            transactionHash: mockTransactionHash,
+            userOpHash: mockUserOpHash,
+            userTelegramID: mockUserTelegramID,
+            status: GX_ORDER_STATUS.PENDING_USD,
+            g1_amount: '1000.00',
+            orderId: mockOrderID,
+          },
+        ]);
+    });
+
+    it('Should update the database with a complete status if order is not present in database and USD amount is 0', async function () {
+      await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID1,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      const orders = await collectionOrdersMock.find({}).toArray();
+
+      chai
+        .expect(orders)
+        .excluding(['_id', 'date'])
+        .to.deep.equal([
+          {
+            transactionHash: mockTransactionHash,
+            userOpHash: mockUserOpHash,
+            userTelegramID: mockUserTelegramID,
+            status: GX_ORDER_STATUS.COMPLETE,
+            g1_amount: '1000.00',
+            orderId: mockOrderID1,
+          },
+        ]);
+    });
+
+    it('Should update the database with a failure status if order is not present in database and failure in token transfer', async function () {
+      axiosStub.withArgs(PATCHWALLET_TX_URL).rejects({
+        response: {
+          status: 470,
+        },
+      });
+
+      const res = await chai
+        .request(app)
+        .post('/v1/tge/pre-order')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .send({
+          quoteId: mockOrderID1,
+          userTelegramID: mockUserTelegramID,
+        });
+
+      const orders = await collectionOrdersMock.find({}).toArray();
+
+      chai
+        .expect(orders)
+        .excluding(['_id', 'date'])
+        .to.deep.equal([
+          {
+            userTelegramID: mockUserTelegramID,
+            status: GX_ORDER_STATUS.FAILURE,
+            g1_amount: '1000.00',
+            orderId: mockOrderID1,
+          },
+        ]);
+
+      chai.expect(res.body.msg).to.be.equal('An error occurred');
+    });
+  });
+});

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -6,8 +6,11 @@ import {
   USERS_COLLECTION,
   SWAPS_COLLECTION,
   VESTING_COLLECTION,
+  GX_QUOTE_COLLECTION,
+  GX_ORDER_COLLECTION,
 } from '../utils/constants';
 import { GRINDERY_NEXUS_REFRESH_TOKEN } from '../../secrets';
+import { v4 as uuidv4, version, validate } from 'uuid';
 
 /**
  * Retrieves the database mock instance.
@@ -16,6 +19,16 @@ import { GRINDERY_NEXUS_REFRESH_TOKEN } from '../../secrets';
 export async function getDbMock() {
   const dbMock = await Database.getInstance();
   return dbMock;
+}
+
+export async function getCollectionGXQuoteMock() {
+  const dbMock = await getDbMock();
+  return dbMock.collection(GX_QUOTE_COLLECTION);
+}
+
+export async function getCollectionGXOrderMock() {
+  const dbMock = await getDbMock();
+  return dbMock.collection(GX_ORDER_COLLECTION);
 }
 
 /**
@@ -149,3 +162,15 @@ async function getAccessToken(): Promise<string> {
  * Mocked token retrieved as an access token.
  */
 export const mockedToken = getAccessToken();
+
+/**
+ * Checks if the provided string is a valid UUID v4.
+ * @param {string} input - The string to check for UUID v4 validity.
+ * @returns {boolean} - Returns true if the input is a valid UUID v4, otherwise false.
+ */
+export function isUUIDv4(input: string): boolean {
+  return validate(input) && version(input) === 4;
+}
+
+export const mockOrderID = uuidv4();
+export const mockOrderID1 = uuidv4();

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -21,16 +21,23 @@ export async function getDbMock() {
   return dbMock;
 }
 
+/**
+ * Retrieves the mock collection instance for GX quotes.
+ * @returns A promise resolving to the mock collection instance for GX quotes.
+ */
 export async function getCollectionGXQuoteMock() {
   const dbMock = await getDbMock();
   return dbMock.collection(GX_QUOTE_COLLECTION);
 }
 
+/**
+ * Retrieves the mock collection instance for GX orders.
+ * @returns  A promise resolving to the mock collection instance for GX orders.
+ */
 export async function getCollectionGXOrderMock() {
   const dbMock = await getDbMock();
   return dbMock.collection(GX_ORDER_COLLECTION);
 }
-
 /**
  * Retrieves the collection for mock users.
  * @returns A promise resolving to the collection of mock users.
@@ -172,5 +179,14 @@ export function isUUIDv4(input: string): boolean {
   return validate(input) && version(input) === 4;
 }
 
+/**
+ * Mock order ID generated using uuidv4().
+ * @type {string}
+ */
 export const mockOrderID = uuidv4();
+
+/**
+ * Another mock order ID generated using uuidv4().
+ * @type {string}
+ */
 export const mockOrderID1 = uuidv4();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,9 @@
 import { SOURCE_WALLET_ADDRESS } from '../../secrets';
 
+export const GX_QUOTE_COLLECTION = 'gx-quote';
+
+export const GX_ORDER_COLLECTION = 'gx-order';
+
 /**
  * Collection name for storing transfers.
  */
@@ -79,6 +83,13 @@ export const TRANSACTION_STATUS = {
   FAILURE: 'failure',
   PENDING_HASH: 'pending_hash',
   FAILURE_503: 'failure_503',
+} as const;
+
+export const GX_ORDER_STATUS = {
+  PENDING: 'pending',
+  COMPLETE: 'complete',
+  FAILURE: 'failure',
+  PENDING_USD: 'waiting_usd',
 } as const;
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -85,6 +85,9 @@ export const TRANSACTION_STATUS = {
   FAILURE_503: 'failure_503',
 } as const;
 
+/**
+ * Various statuses for GX orders.
+ */
 export const GX_ORDER_STATUS = {
   PENDING: 'pending',
   COMPLETE: 'complete',


### PR DESCRIPTION
This PR introduces new routes for handling TGE pre-orders. It includes endpoint setups and necessary logic to enable users to initiate pre-orders for token purchases during the TGE phase.
