### PR TITLE
feat: replace generic `Document` type by proper Mongo types

### DIFF
--- a/src/types/hedgey.types.ts
+++ b/src/types/hedgey.types.ts
@@ -1,6 +1,7 @@
-import { Document, WithId } from 'mongodb';
+import { WithId } from 'mongodb';
 import { DEFAULT_CHAIN_ID, G1_TOKEN_SYMBOL } from '../utils/constants';
 import { G1_POLYGON_ADDRESS } from '../../secrets';
+import { MongoUser } from './mongo.types';
 
 export type HedgeyRecipientParams = {
   /** The address of the recipient. */
@@ -41,7 +42,7 @@ export type VestingParams = {
   /** The symbol of the token for the transaction. */
   tokenSymbol?: string;
   /** Additional sender information with MongoDB document ID. */
-  senderInformation?: WithId<Document>;
+  senderInformation?: WithId<MongoUser>;
 };
 
 /**
@@ -52,7 +53,7 @@ export type VestingParams = {
  */
 export function createVesting(
   params: VestingParams,
-  senderInformation: WithId<Document>,
+  senderInformation: WithId<MongoUser>,
 ): VestingParams {
   return {
     ...{

--- a/src/types/mongo.types.ts
+++ b/src/types/mongo.types.ts
@@ -1,0 +1,222 @@
+import { HedgeyRecipientParams } from './hedgey.types';
+import { TransactionStatus } from './webhook.types';
+
+/**
+ * Represents a MongoDB document for Transfer transactions.
+ */
+export type MongoTransfer = {
+  /** Unique event identifier */
+  eventId: string;
+
+  /** Chain identifier */
+  chainId: string;
+
+  /** Token symbol */
+  tokenSymbol: string;
+
+  /** Token address */
+  tokenAddress: string;
+
+  /** Telegram ID of the sender */
+  senderTgId: string;
+
+  /** Telegram ID of the recipient */
+  recipientTgId: string;
+
+  /** Amount of tokens transferred */
+  tokenAmount: string;
+
+  /** Status of the transaction */
+  status: TransactionStatus;
+
+  /** Date when the transfer was added */
+  dateAdded: Date;
+
+  /** Transaction ID */
+  TxId: string;
+
+  /** Wallet address of the recipient */
+  recipientWallet: string;
+
+  /** Handle of the sender */
+  senderHandle: string;
+
+  /** Name of the sender */
+  senderName: string;
+
+  /** Wallet address of the sender */
+  senderWallet: string;
+
+  /** Transaction hash */
+  transactionHash: string;
+
+  /** User operation hash */
+  userOpHash: string;
+};
+
+/**
+ * Represents a MongoDB document for User details.
+ */
+export type MongoUser = {
+  /** Telegram user ID */
+  userTelegramID: string;
+
+  /** Response path */
+  responsePath: string;
+
+  /** User handle */
+  userHandle: string;
+
+  /** User name */
+  userName: string;
+
+  /** Wallet address */
+  patchwallet: string;
+
+  /** Optional Telegram session */
+  telegramSession?: string;
+};
+
+/**
+ * Represents a MongoDB document for Reward transactions.
+ */
+export type MongoReward = {
+  /** Telegram user ID */
+  userTelegramID: string;
+
+  /** Response path */
+  responsePath: string;
+
+  /** Wallet address */
+  walletAddress: string;
+
+  /** Reason for reward */
+  reason: string;
+
+  /** User handle */
+  userHandle: string;
+
+  /** User name */
+  userName: string;
+
+  /** Amount of the reward */
+  amount: string;
+
+  /** Message associated with the reward */
+  message: string;
+
+  /** Transaction hash */
+  transactionHash: string;
+
+  /** User operation hash */
+  userOpHash: string;
+
+  /** Date when the reward was added */
+  dateAdded: Date;
+
+  /** Status of the transaction */
+  status: TransactionStatus;
+};
+
+/**
+ * Represents a MongoDB document for Swap transactions.
+ */
+export type MongoSwap = {
+  /** Unique event identifier */
+  eventId: string;
+
+  /** Chain identifier */
+  chainId: string;
+
+  /** Address of the recipient */
+  to: string;
+
+  /** Telegram user ID */
+  userTelegramID: string;
+
+  /** Token in */
+  tokenIn: string;
+
+  /** Amount of token in */
+  amountIn: string;
+
+  /** Token out */
+  tokenOut: string;
+
+  /** Amount of token out */
+  amountOut: string;
+
+  /** Price impact */
+  priceImpact: string;
+
+  /** Gas used */
+  gas: string;
+
+  /** Status of the transaction */
+  status: TransactionStatus;
+
+  /** Date when the swap was added */
+  dateAdded: Date;
+
+  /** Transaction ID */
+  TxId: string;
+
+  /** Transaction hash */
+  transactionHash: string;
+
+  /** User operation hash */
+  userOpHash: string;
+
+  /** User handle */
+  userHandle: string;
+
+  /** User name */
+  userName: string;
+
+  /** User wallet */
+  userWallet: string;
+};
+
+/**
+ * Represents a MongoDB document for Vesting details.
+ */
+export type MongoVesting = {
+  /** Unique event identifier */
+  eventId: string;
+
+  /** Chain identifier */
+  chainId: string;
+
+  /** Token symbol */
+  tokenSymbol: string;
+
+  /** Token address */
+  tokenAddress: string;
+
+  /** Telegram ID of the sender */
+  senderTgId: string;
+
+  /** Wallet address of the sender */
+  senderWallet: string;
+
+  /** Name of the sender */
+  senderName: string;
+
+  /** Handle of the sender */
+  senderHandle: string;
+
+  /** Recipients with Vesting details */
+  recipients: HedgeyRecipientParams[];
+
+  /** Status of the transaction */
+  status: TransactionStatus;
+
+  /** Date when the vesting was added */
+  dateAdded: Date;
+
+  /** Transaction hash */
+  transactionHash: string;
+
+  /** User operation hash */
+  userOpHash: string;
+};

--- a/src/types/mongo.types.ts
+++ b/src/types/mongo.types.ts
@@ -32,9 +32,6 @@ export type MongoTransfer = {
   /** Date when the transfer was added */
   dateAdded: Date;
 
-  /** Transaction ID */
-  TxId: string;
-
   /** Wallet address of the recipient */
   recipientWallet: string;
 
@@ -157,9 +154,6 @@ export type MongoSwap = {
 
   /** Date when the swap was added */
   dateAdded: Date;
-
-  /** Transaction ID */
-  TxId: string;
 
   /** Transaction hash */
   transactionHash: string;

--- a/src/types/webhook.types.ts
+++ b/src/types/webhook.types.ts
@@ -27,48 +27,68 @@ export type TransactionStatus =
 export type SwapParams = {
   /** The value of the swap. */
   value: string;
+
   /** The event ID associated with the swap. */
   eventId: string;
+
   /** The Telegram user ID associated with the swap. */
   userTelegramID: string;
+
   /** Additional user information with MongoDB document ID. */
   userInformation?: WithId<MongoUser>;
+
   /** The recipient wallet address. */
   to?: string;
+
   /** Additional data for the swap. */
   data?: string;
+
   /** The input token for the swap. */
   tokenIn: string;
+
   /** The amount of input tokens. */
   amountIn: string;
+
   /** The output token for the swap. */
   tokenOut: string;
+
   /** The amount of output tokens. */
   amountOut: string;
+
   /** The price impact of the swap. */
   priceImpact: string;
+
   /** The gas value for the swap. */
   gas: string;
+
   /** The sender's address for the swap. */
   from: string;
+
   /** The symbol of the input token. */
   tokenInSymbol: string;
+
   /** The symbol of the output token. */
   tokenOutSymbol: string;
+
   /** The chain ID for the swap. */
   chainId?: string;
+
   /** Additional amount information for the swap. */
   amount?: string;
+
   /** The Telegram user ID of the sender. */
   senderTgId?: string;
+
   /**
    * Represents whether the transaction is a delegate call.
    * - `0` for non-delegate call
    * - `1` for delegate call
    */
   delegatecall?: 0 | 1;
+
   /** The chain in ID for the swap/bridge. */
   chainIn?: string;
+
   /** The chain out ID for the swap/bridge. */
   chainOut?: string;
 };
@@ -111,35 +131,49 @@ export type TrackSwapSegmentParams = SwapParams & {
 export type RewardParams = {
   /** The event ID associated with the reward. */
   eventId: string;
+
   /** The Telegram user ID associated with the reward. */
   userTelegramID: string;
+
   /** The path for the response. */
   responsePath?: string;
+
   /** The handle of the user. */
   userHandle?: string;
+
   /** The name of the user. */
   userName?: string;
+
   /** The wallet patch information. */
   patchwallet?: string;
+
   /** The reason for the reward. */
   reason?: string;
+
   /** The message associated with the reward. */
   message?: string;
+
   /** The amount for the reward. */
   amount?: string;
+
   /** The token address for the reward. */
   tokenAddress?: string;
+
   /** The chain id for the reward. */
   chainId?: string;
 
   /** The Telegram user ID of the referent. */
   referentUserTelegramID?: string;
+
   /** Specifies if there is a signup reward. */
   isSignupReward?: boolean;
+
   /** Specifies if there is a referral reward. */
   isReferralReward?: boolean;
+
   /** Specifies if there is a link reward. */
   isLinkReward?: boolean;
+
   /**
    * Represents whether the transaction is a delegate call.
    * - `0` for non-delegate call
@@ -187,22 +221,31 @@ export type IdentitySegmentParams = RewardParams & {
 export type TransactionParams = {
   /** The Telegram user ID of the sender. */
   senderTgId: string;
+
   /** The amount of the transaction. */
   amount: string;
+
   /** The Telegram user ID of the recipient. */
   recipientTgId: string;
+
   /** The event ID associated with the transaction. */
   eventId: string;
+
   /** The chain ID for the transaction. */
   chainId?: string;
+
   /** The token address for the transaction. */
   tokenAddress?: string;
+
   /** The message associated with the transaction. */
   message?: string;
+
   /** The symbol of the token for the transaction. */
   tokenSymbol?: string;
+
   /** Additional sender information with MongoDB document ID. */
   senderInformation?: WithId<MongoUser>;
+
   /**
    * Represents whether the transaction is a delegate call.
    * - `0` for non-delegate call
@@ -240,8 +283,10 @@ export function createTransaction(
 export type TrackSegmentParams = TransactionParams & {
   /** The wallet address of the recipient. */
   recipientWallet: string;
+
   /** The hash associated with the transaction. */
   transactionHash: string;
+
   /** The date when the segment was added. */
   dateAdded: Date;
 };
@@ -277,6 +322,7 @@ export type TelegramOperations =
 export interface PatchRawResult {
   /** The user operation hash, if available. */
   userOpHash?: string;
+
   /** The transaction hash, if available. */
   txHash?: string;
 }

--- a/src/types/webhook.types.ts
+++ b/src/types/webhook.types.ts
@@ -1,4 +1,4 @@
-import { Document, WithId } from 'mongodb';
+import { WithId } from 'mongodb';
 import {
   DEFAULT_CHAIN_ID,
   G1_TOKEN_SYMBOL,
@@ -12,6 +12,7 @@ import { SignUpRewardTelegram } from '../webhooks/signup-reward';
 import { ReferralRewardTelegram } from '../webhooks/referral-reward';
 import { LinkRewardTelegram } from '../webhooks/link-reward';
 import { IsolatedRewardTelegram } from '../webhooks/isolated-reward';
+import { MongoUser } from './mongo.types';
 
 /**
  * Represents the various transaction statuses.
@@ -31,7 +32,7 @@ export type SwapParams = {
   /** The Telegram user ID associated with the swap. */
   userTelegramID: string;
   /** Additional user information with MongoDB document ID. */
-  userInformation?: WithId<Document>;
+  userInformation?: WithId<MongoUser>;
   /** The recipient wallet address. */
   to?: string;
   /** Additional data for the swap. */
@@ -79,7 +80,7 @@ export type SwapParams = {
  */
 export function createSwapParams(
   params: SwapParams,
-  userInformation: WithId<Document>,
+  userInformation: WithId<MongoUser>,
 ): SwapParams {
   return {
     ...{
@@ -201,7 +202,7 @@ export type TransactionParams = {
   /** The symbol of the token for the transaction. */
   tokenSymbol?: string;
   /** Additional sender information with MongoDB document ID. */
-  senderInformation?: WithId<Document>;
+  senderInformation?: WithId<MongoUser>;
   /**
    * Represents whether the transaction is a delegate call.
    * - `0` for non-delegate call
@@ -218,7 +219,7 @@ export type TransactionParams = {
  */
 export function createTransaction(
   params: TransactionParams,
-  senderInformation: WithId<Document>,
+  senderInformation: WithId<MongoUser>,
 ): TransactionParams {
   return {
     ...{

--- a/src/utils/patchwallet.ts
+++ b/src/utils/patchwallet.ts
@@ -172,7 +172,7 @@ export async function swapTokens(
  * @returns {Promise<axios.AxiosResponse<PatchRawResult, AxiosError>>} - Promise resolving to the response from the PayMagic API.
  */
 export async function hedgeyLockTokens(
-  senderTgId: string,
+  senderTgId: string | undefined,
   recipients: HedgeyRecipientParams[],
   patchWalletAccessToken: string,
   useVesting: boolean = false,
@@ -183,7 +183,7 @@ export async function hedgeyLockTokens(
 
   // Lock the tokens using PayMagic API
   return await callPatchWalletTx(
-    senderTgId,
+    senderTgId || '',
     chainId,
     HEDGEY_BATCHPLANNER_ADDRESS,
     '0x00',

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -2,8 +2,9 @@ import { Api } from 'telegram';
 import { StringSession } from 'telegram/sessions/index';
 import TGClient from './telegramClient';
 import { decrypt } from './crypt';
-import { WithId, Document } from 'mongodb';
+import { WithId } from 'mongodb';
 import { TelegramMessageResponse } from '../types/telegram.types';
+import { MongoUser } from '../types/mongo.types';
 
 /**
  * Sends a message via Telegram to a recipient.
@@ -17,7 +18,7 @@ import { TelegramMessageResponse } from '../types/telegram.types';
 export const sendTelegramMessage = async (
   message: string,
   recipientId: string,
-  senderUser: WithId<Document>,
+  senderUser: WithId<MongoUser>,
 ): Promise<TelegramMessageResponse> => {
   try {
     // Validation checks for required parameters

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,9 +1,10 @@
-import { Db, Document, WithId } from 'mongodb';
+import { Db, WithId } from 'mongodb';
 import { Database } from '../db/conn';
 import { REWARDS_COLLECTION, USERS_COLLECTION } from './constants';
 import { getPatchWalletAddressFromTgId } from './patchwallet';
 import { addIdentitySegment } from './segment';
 import { RewardParams } from '../types/webhook.types';
+import { MongoReward, MongoUser } from '../types/mongo.types';
 
 /**
  * Creates a new instance of UserTelegram and initializes its database.
@@ -68,13 +69,13 @@ export class UserTelegram {
 
   /**
    * Retrieves user data from the database.
-   * @returns {Promise<WithId<Document>>} - The user data from the database.
+   * @returns {Promise<WithId<MongoUser>>} - The user data from the database.
    */
-  async getUserFromDatabase(): Promise<WithId<Document> | null> {
+  async getUserFromDatabase(): Promise<WithId<MongoUser> | null> {
     if (this.db)
-      return await this.db
-        .collection(USERS_COLLECTION)
-        .findOne({ userTelegramID: this.params.userTelegramID });
+      return (await this.db.collection(USERS_COLLECTION).findOne({
+        userTelegramID: this.params.userTelegramID,
+      })) as WithId<MongoUser>;
     return null;
   }
 
@@ -143,15 +144,15 @@ export class UserTelegram {
    * Retrieves the sign-up rewards for the user.
    * @returns {Promise<Array>} - An array of sign-up rewards.
    */
-  async getSignUpReward(): Promise<WithId<Document>[] | []> {
+  async getSignUpReward(): Promise<WithId<MongoReward>[] | []> {
     if (this.db)
-      return await this.db
+      return (await this.db
         .collection(REWARDS_COLLECTION)
         .find({
           userTelegramID: this.params.userTelegramID,
           reason: 'user_sign_up',
         })
-        .toArray();
+        .toArray()) as WithId<MongoReward>[];
     return [];
   }
 
@@ -167,15 +168,15 @@ export class UserTelegram {
    * Retrieves referral rewards for the user.
    * @returns {Promise<Array>} - An array of referral rewards.
    */
-  async getReferralRewards(): Promise<WithId<Document>[] | []> {
+  async getReferralRewards(): Promise<WithId<MongoReward>[] | []> {
     if (this.db)
-      return await this.db
+      return (await this.db
         .collection(REWARDS_COLLECTION)
         .find({
           userTelegramID: this.params.userTelegramID,
           reason: '2x_reward',
         })
-        .toArray();
+        .toArray()) as WithId<MongoReward>[];
     return [];
   }
 
@@ -191,15 +192,15 @@ export class UserTelegram {
    * Retrieves link rewards for the user.
    * @returns {Promise<Array>} - An array of link rewards.
    */
-  async getLinkRewards(): Promise<WithId<Document>[] | []> {
+  async getLinkRewards(): Promise<WithId<MongoReward>[] | []> {
     if (this.db)
-      return await this.db
+      return (await this.db
         .collection(REWARDS_COLLECTION)
         .find({
           userTelegramID: this.params.userTelegramID,
           reason: 'referral_link',
         })
-        .toArray();
+        .toArray()) as WithId<MongoReward>[];
     return [];
   }
 

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -75,7 +75,7 @@ export class UserTelegram {
     if (this.db)
       return (await this.db.collection(USERS_COLLECTION).findOne({
         userTelegramID: this.params.userTelegramID,
-      })) as WithId<MongoUser>;
+      })) as WithId<MongoUser> | null;
     return null;
   }
 
@@ -152,7 +152,7 @@ export class UserTelegram {
           userTelegramID: this.params.userTelegramID,
           reason: 'user_sign_up',
         })
-        .toArray()) as WithId<MongoReward>[];
+        .toArray()) as WithId<MongoReward>[] | [];
     return [];
   }
 
@@ -176,7 +176,7 @@ export class UserTelegram {
           userTelegramID: this.params.userTelegramID,
           reason: '2x_reward',
         })
-        .toArray()) as WithId<MongoReward>[];
+        .toArray()) as WithId<MongoReward>[] | [];
     return [];
   }
 
@@ -200,7 +200,7 @@ export class UserTelegram {
           userTelegramID: this.params.userTelegramID,
           reason: 'referral_link',
         })
-        .toArray()) as WithId<MongoReward>[];
+        .toArray()) as WithId<MongoReward>[] | [];
     return [];
   }
 

--- a/src/webhooks/isolated-reward.ts
+++ b/src/webhooks/isolated-reward.ts
@@ -210,7 +210,7 @@ export class IsolatedRewardTelegram {
         userTelegramID: this.params.userTelegramID,
         eventId: this.params.eventId,
         reason: this.params.reason,
-      })) as WithId<MongoReward>;
+      })) as WithId<MongoReward> | null;
     return null;
   }
 

--- a/src/webhooks/isolated-reward.ts
+++ b/src/webhooks/isolated-reward.ts
@@ -27,8 +27,9 @@ import {
   updateTxHash,
   updateUserOpHash,
 } from './utils';
-import { Db, Document, WithId } from 'mongodb';
+import { Db, WithId } from 'mongodb';
 import { Database } from '../db/conn';
+import { MongoReward } from '../types/mongo.types';
 
 /**
  * Handles the processing of an isolated reward based on specified parameters.
@@ -120,7 +121,7 @@ export class IsolatedRewardTelegram {
   isInDatabase: boolean = false;
 
   /** Transaction details. */
-  tx: WithId<Document> | null;
+  tx: WithId<MongoReward> | null;
 
   /** Current status of the reward. */
   status: TransactionStatus;
@@ -201,15 +202,15 @@ export class IsolatedRewardTelegram {
 
   /**
    * Retrieves the status of the PatchWallet transaction.
-   * @returns {Promise<WithId<Document>>} - True if the transaction status is retrieved successfully, false otherwise.
+   * @returns {Promise<WithId<MongoReward>>} - True if the transaction status is retrieved successfully, false otherwise.
    */
-  async getRewardFromDatabase(): Promise<WithId<Document> | null> {
+  async getRewardFromDatabase(): Promise<WithId<MongoReward> | null> {
     if (this.db)
-      return await this.db.collection(REWARDS_COLLECTION).findOne({
+      return (await this.db.collection(REWARDS_COLLECTION).findOne({
         userTelegramID: this.params.userTelegramID,
         eventId: this.params.eventId,
         reason: this.params.reason,
-      });
+      })) as WithId<MongoReward>;
     return null;
   }
 

--- a/src/webhooks/link-reward.ts
+++ b/src/webhooks/link-reward.ts
@@ -204,7 +204,7 @@ export class LinkRewardTelegram {
     if (this.db)
       this.referent = (await this.db.collection(USERS_COLLECTION).findOne({
         userTelegramID: this.params.referentUserTelegramID,
-      })) as WithId<MongoUser>;
+      })) as WithId<MongoUser> | null;
 
     if (this.referent) {
       this.referent.patchwallet =
@@ -227,7 +227,7 @@ export class LinkRewardTelegram {
         userTelegramID: this.params.referentUserTelegramID,
         sponsoredUserTelegramID: this.params.userTelegramID,
         reason: this.params.reason,
-      })) as WithId<MongoReward>;
+      })) as WithId<MongoReward> | null;
     return null;
   }
 

--- a/src/webhooks/signup-reward.ts
+++ b/src/webhooks/signup-reward.ts
@@ -192,7 +192,7 @@ export class SignUpRewardTelegram {
         userTelegramID: this.params.userTelegramID,
         eventId: this.params.eventId,
         reason: this.params.reason,
-      })) as WithId<MongoReward>;
+      })) as WithId<MongoReward> | null;
     return null;
   }
 

--- a/src/webhooks/signup-reward.ts
+++ b/src/webhooks/signup-reward.ts
@@ -23,8 +23,9 @@ import {
   updateTxHash,
   updateUserOpHash,
 } from './utils';
-import { Db, Document, WithId } from 'mongodb';
+import { Db, WithId } from 'mongodb';
 import { Database } from '../db/conn';
+import { MongoReward } from '../types/mongo.types';
 
 /**
  * Handles the processing of a sign-up reward based on specified parameters.
@@ -113,7 +114,7 @@ export class SignUpRewardTelegram {
   isInDatabase: boolean = false;
 
   /** Transaction details of the reward. */
-  tx: WithId<Document> | null;
+  tx: WithId<MongoReward> | null;
 
   /** Current status of the reward. */
   status: TransactionStatus;
@@ -183,15 +184,15 @@ export class SignUpRewardTelegram {
 
   /**
    * Retrieves the status of the PatchWallet transaction.
-   * @returns {Promise<boolean>} - True if the transaction status is retrieved successfully, false otherwise.
+   * @returns {Promise<MongoReward>} - True if the transaction status is retrieved successfully, false otherwise.
    */
-  async getRewardFromDatabase(): Promise<WithId<Document> | null> {
+  async getRewardFromDatabase(): Promise<WithId<MongoReward> | null> {
     if (this.db)
-      return await this.db.collection(REWARDS_COLLECTION).findOne({
+      return (await this.db.collection(REWARDS_COLLECTION).findOne({
         userTelegramID: this.params.userTelegramID,
         eventId: this.params.eventId,
         reason: this.params.reason,
-      });
+      })) as WithId<MongoReward>;
     return null;
   }
 

--- a/src/webhooks/utils.ts
+++ b/src/webhooks/utils.ts
@@ -81,7 +81,8 @@ export async function isTreatmentDurationExceeded(
   telegram_operation: TelegramOperations,
 ): Promise<boolean> {
   return (
-    (telegram_operation.tx?.dateAdded < getXMinBeforeDate(new Date(), 10) &&
+    (telegram_operation.tx &&
+      telegram_operation.tx.dateAdded < getXMinBeforeDate(new Date(), 10) &&
       (console.log(
         `[${telegram_operation.params.eventId}] was stopped due to too long treatment duration (> 10 min).`,
       ),


### PR DESCRIPTION
Using the generic bson `Document` type:

```typescript
/** @public */
export declare interface Document {
    [key: string]: any;
}
```
is quite unsafe because it connects keys of type `string` to values of type  `any`. So there is no precise way to verify, for example, that the fields really exist (and are of a correct type) at the location concerned.

So, I created specific types which group together all the fields that we have in each of our collections in order to type all our interactions with the database in a secure manner.