### PR TITLE
feat: add `validateUserTelegramID` util method and unit tests

### DIFF
--- a/mocha.mocharc.cjs
+++ b/mocha.mocharc.cjs
@@ -3,5 +3,5 @@ module.exports = {
   exit: true,
   require: ['ts-node/register', './src/test/hooks.ts'],
   'async-only': true,
-  retries: 4,
+  retries: 0,
 };

--- a/mocha.mocharc.cjs
+++ b/mocha.mocharc.cjs
@@ -3,5 +3,5 @@ module.exports = {
   exit: true,
   require: ['ts-node/register', './src/test/hooks.ts'],
   'async-only': true,
-  retries: 0,
+  retries: 4,
 };

--- a/src/test/validators/webhooks.validator.test.ts
+++ b/src/test/validators/webhooks.validator.test.ts
@@ -81,14 +81,14 @@ describe('Webhook validators', function () {
         {
           type: 'field',
           value: 12345,
-          msg: 'userTelegramID must be a string',
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
           path: 'params.userTelegramID',
           location: 'body',
         },
         {
           type: 'field',
           value: 12345,
-          msg: 'referentUserTelegramID must be a string',
+          msg: 'params.referentUserTelegramID must be a string representing a 64-bit little-endian number',
           path: 'params.referentUserTelegramID',
           location: 'body',
         },
@@ -223,14 +223,14 @@ describe('Webhook validators', function () {
         {
           type: 'field',
           value: 12345,
-          msg: 'senderTgId must be a string',
+          msg: 'params.senderTgId must be a string representing a 64-bit little-endian number',
           path: 'params.senderTgId',
           location: 'body',
         },
         {
           type: 'field',
           value: 67890,
-          msg: 'recipientTgId must be a string',
+          msg: 'params.recipientTgId must be a string representing a 64-bit little-endian number',
           path: 'params.recipientTgId',
           location: 'body',
         },
@@ -355,7 +355,7 @@ describe('Webhook validators', function () {
         {
           type: 'field',
           value: 12345,
-          msg: 'senderTgId must be a string',
+          msg: 'params.*.senderTgId must be a string representing a 64-bit little-endian number',
           path: 'params[0].senderTgId',
           location: 'body',
         },
@@ -530,6 +530,13 @@ describe('Webhook validators', function () {
         },
         {
           type: 'field',
+          value: 12345,
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+        {
+          type: 'field',
           value: '0x105E9152e3d4F5486f2953eF6578f7e25c27C3501',
           msg: 'to must be a valid address',
           path: 'params.to',
@@ -579,6 +586,13 @@ describe('Webhook validators', function () {
         },
         {
           type: 'field',
+          value: true,
+          msg: 'params.senderTgId must be a string representing a 64-bit little-endian number',
+          path: 'params.senderTgId',
+          location: 'body',
+        },
+        {
+          type: 'field',
           value: 2,
           msg: 'delegatecall must be either 0 or 1',
           path: 'params.delegatecall',
@@ -589,13 +603,6 @@ describe('Webhook validators', function () {
           value: 100,
           msg: 'value must be a string',
           path: 'params.value',
-          location: 'body',
-        },
-        {
-          type: 'field',
-          value: 12345,
-          msg: 'userTelegramID must be a string',
-          path: 'params.userTelegramID',
           location: 'body',
         },
         {
@@ -659,13 +666,6 @@ describe('Webhook validators', function () {
           value: 123,
           msg: 'chainName must be a string',
           path: 'params.chainName',
-          location: 'body',
-        },
-        {
-          type: 'field',
-          value: true,
-          msg: 'senderTgId must be a string',
-          path: 'params.senderTgId',
           location: 'body',
         },
       ]);
@@ -747,6 +747,13 @@ describe('Webhook validators', function () {
         },
         {
           type: 'field',
+          value: 12345,
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+        {
+          type: 'field',
           value: '0x105E9152e3d4F5486f2953eF6578f7e25c27C3501',
           msg: 'patchwallet must be a valid address',
           path: 'params.patchwallet',
@@ -764,6 +771,13 @@ describe('Webhook validators', function () {
           value: '0x105E9152e3d4F5486f2953eF6578f7e25c27C3501',
           msg: 'tokenAddress must be a valid address',
           path: 'params.tokenAddress',
+          location: 'body',
+        },
+        {
+          type: 'field',
+          value: 67890,
+          msg: 'params.referentUserTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.referentUserTelegramID',
           location: 'body',
         },
         {
@@ -792,13 +806,6 @@ describe('Webhook validators', function () {
           value: 2,
           msg: 'delegatecall must be either 0 or 1',
           path: 'params.delegatecall',
-          location: 'body',
-        },
-        {
-          type: 'field',
-          value: 12345,
-          msg: 'userTelegramID must be a string',
-          path: 'params.userTelegramID',
           location: 'body',
         },
         {
@@ -841,13 +848,6 @@ describe('Webhook validators', function () {
           value: 123,
           msg: 'chainName must be a string',
           path: 'params.chainName',
-          location: 'body',
-        },
-        {
-          type: 'field',
-          value: 67890,
-          msg: 'referentUserTelegramID must be a string',
-          path: 'params.referentUserTelegramID',
           location: 'body',
         },
       ]);

--- a/src/test/validators/webhooks.validator.utils.test.ts
+++ b/src/test/validators/webhooks.validator.utils.test.ts
@@ -1,0 +1,220 @@
+import { expect } from 'chai';
+import { validateResult, validateUserTelegramID } from '../../validators/utils';
+
+describe('Webhook validator utils', async function () {
+  describe('validateUserTelegramID function', async function () {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockRequest = (value: any) => ({
+      body: {
+        params: {
+          userTelegramID: value,
+        },
+      },
+    });
+
+    it('should validate userTelegramID correctly when it is a valid user ID as string', async function () {
+      const userIds = [
+        '6175053757',
+        '5113589246',
+        '5187014279',
+        '2074945217',
+        '6204624638',
+        '5829303669',
+        '5866002866',
+        '5015274944',
+        '5929081775',
+        '1652911558',
+        '1696490709',
+        '1838765561',
+        '5434363584',
+        '5000418861',
+        '5582190332',
+        '1343115693',
+        '5634434425',
+        '1553816371',
+        '5557160897',
+        '1648718110',
+        '5615394828',
+        '5528310884',
+        '5340720350',
+        '5441957203',
+        '1951161250',
+        '691030271',
+        '5582609945',
+        '6517588026',
+        '5484554724',
+        '5529499291',
+        '5580380153',
+        '6696274329',
+        '6529345212',
+        '1698212051',
+        '6517366518',
+        '1574174783',
+        '1153134395',
+        '1225570899',
+        '5598871444',
+        '1209782486',
+      ];
+
+      for (const userId of userIds) {
+        const validateFunction = validateUserTelegramID(
+          'params.userTelegramID',
+          false,
+        );
+
+        const req = mockRequest(userId);
+
+        await validateFunction(req, {}, () => {});
+
+        expect(validateResult(req)).to.be.empty;
+      }
+    });
+
+    it('Should throw an error when value is an Ethereum address', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest('0xfFEE087852cb4898e6c3532E776e68BC68b1143B');
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: '0xfFEE087852cb4898e6c3532E776e68BC68b1143B',
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('should validate userTelegramID correctly when it is a number', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest(5113589246);
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: 5113589246,
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('Should throw an error when value is an empty string', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest('');
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: '',
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('Should throw an error when value is not a string or number', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest({ userTelegramID: 'invalidData' }); // For example, an object instead of a string or number
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: { userTelegramID: 'invalidData' },
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('Should throw an error when value is null', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest(null);
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: null,
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('Should throw an error when value is a boolean', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest(true); // or false
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: true, // or false
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+
+    it('Should throw an error when value is a non-hexadecimal string', async function () {
+      const validateFunction = validateUserTelegramID(
+        'params.userTelegramID',
+        false,
+      );
+
+      const req = mockRequest('notahexadecimalstring');
+
+      await validateFunction(req, {}, () => {});
+
+      expect(validateResult(req)).to.deep.equal([
+        {
+          type: 'field',
+          value: 'notahexadecimalstring',
+          msg: 'params.userTelegramID must be a string representing a 64-bit little-endian number',
+          path: 'params.userTelegramID',
+          location: 'body',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

At the moment, Telegram user IDs are only validated on the basis that they must be strings. 

But with the description given here https://core.telegram.org/type/long, we can do a much more precise validation, in order to ensure, for example, that Ethereum addresses or random strings can never enter while waiting for a user ID.

Added a new utility method `validateUserTelegramID` along with corresponding unit tests to ensure accurate validation of user Telegram IDs.

## Changes Made

- Implemented `validateUserTelegramID` utility method to validate user Telegram IDs.
- Included thorough unit tests to verify the functionality and edge cases of the new utility method.


