### PR TITLE
add hardcap for USD investment

### DIFF
--- a/src/test/tge/tge.test.ts
+++ b/src/test/tge/tge.test.ts
@@ -32,6 +32,7 @@ describe('G1 to GX util functions', async function () {
   let sandbox: Sinon.SinonSandbox;
   let collectionQuotesMock;
   let collectionOrdersMock;
+  let conversionStub;
 
   beforeEach(async function () {
     collectionQuotesMock = await getCollectionGXQuoteMock();
@@ -61,7 +62,7 @@ describe('G1 to GX util functions', async function () {
     });
 
     sandbox = Sinon.createSandbox();
-    sandbox.stub(g1gx, 'computeG1ToGxConversion').returns({
+    conversionStub = sandbox.stub(g1gx, 'computeG1ToGxConversion').returns({
       m1: '0.2000',
       m2: '0.4000',
       m3: '0.3000',
@@ -108,6 +109,40 @@ describe('G1 to GX util functions', async function () {
   });
 
   describe('Endpoint for conversion information', async function () {
+    it('Should return an error if total amount invested is more than $10,000 USD', async function () {
+      conversionStub.returns({
+        m1: '0.2000',
+        m2: '0.4000',
+        m3: '0.3000',
+        m4: '0.0000',
+        m5: '0.2500',
+        m6: '1.0000',
+        finalG1Usd: '0.005000',
+        gxFromUsd: '5000.00',
+        usdFromG1: '600000.00',
+        gxFromG1: '16666666.67',
+        gxReceived: '16671666.67',
+        equivalentUsdInvested: '11000',
+        GxUsdExchangeRate: '10.00',
+      });
+
+      const res = await chai
+        .request(app)
+        .get('/v1/tge/quote')
+        .set('Authorization', `Bearer ${await getApiKey()}`)
+        .query({
+          tokenAmount: '10',
+          chainId: mockChainId,
+          tokenAddress: mockTokenAddress,
+          g1Quantity: '10',
+          userTelegramID: mockUserTelegramID,
+        });
+
+      expect(res.body).to.deep.equal({
+        msg: 'The investment amount must not exceed $10,000 USD to proceed.',
+      });
+    });
+
     it('Should return an error if G1 token amount is 0', async function () {
       const res = await chai
         .request(app)


### PR DESCRIPTION
### Description
This pull request introduces a hardcap for USD investment, ensuring that the investment amount does not exceed $10,000 USD. The validation has been added to the relevant part of the code to enforce this limit.

### Changes Made
- Added a check to ensure that the equivalent USD invested does not exceed $10,000 USD.
- Improved error messaging for cases where the hardcap is not met.

