### PR TITLE
add balance check fail safe before quote

### DIFF
--- a/src/utils/g1gx.ts
+++ b/src/utils/g1gx.ts
@@ -1,6 +1,5 @@
 import { G1_POLYGON_ADDRESS } from '../../secrets';
 import { DEFAULT_CHAIN_ID } from './constants';
-// import { daysSinceStartDate } from './time';
 import { UserTelegram } from './user';
 import { getUserBalance } from './web3';
 


### PR DESCRIPTION
### Description
Introduces a balance check fail-safe mechanism before generating a quote in the `/quote` route. This enhancement ensures that the user's G1 and token balances are verified to prevent insufficient balance scenarios. The fail-safe logic includes checks for G1 balance, token balance (if applicable), and a maximum USD investment limit.

### Changes Made
- Added G1 balance check to ensure it's sufficient for the requested token amount.
- Implemented token balance check (if chainId and tokenAmount are provided) to prevent insufficient token balance scenarios.


