### PR TITLE
fix(g1gx): when between 80-95% of G1 is sold, the g1 is valued too high

### DIFF
--- a/src/utils/g1gx.ts
+++ b/src/utils/g1gx.ts
@@ -108,8 +108,7 @@ export function computeG1ToGxConversion(
       ? 0
       : amountG1ToConvert / snapshotG1 < 0.95
       ? (amountG1ToConvert / snapshotG1 - 0.8) *
-        (M5_FACTOR / (0.95 - 0.8)) *
-        100
+        (M5_FACTOR / (0.95 - 0.8)) 
       : M5_FACTOR;
 
   // Calculate m6 as the minimum of the sum of m1, m2, m3, m4, and m5.


### PR DESCRIPTION
It seems that when you sell between 80% and 95% of G1, than there was a factor 100 too high for the amount of G1 sold.